### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/Nitrokey/libnitrokey.png?label=ready&title=Ready)](https://waffle.io/Nitrokey/libnitrokey)
 # libnitrokey
 Libnitrokey is a project to communicate with Nitrokey stick devices in clean and easy manner. Written in C++14, testable with `Catch` framework, with C API, Python access (through CFFI and C API, in future with Pybind11).
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/Nitrokey/libnitrokey

This was requested by a real person (user szszszsz) on waffle.io, we're not trying to spam you.