### PR TITLE
Support for Nitrokey Pro 0.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,9 @@ set(SOURCE_FILES
         unittest/test_C_API.cpp
         unittest/catch_main.cpp
         unittest/test2.cc
+        unittest/test3.cc
         include/LongOperationInProgressException.h
+        include/stick10_commands_0.8.h
         )
 
 add_executable(libnitrokey ${SOURCE_FILES})

--- a/NK_C_API.cc
+++ b/NK_C_API.cc
@@ -471,6 +471,13 @@ extern int NK_get_progress_bar_value() {
   });
 }
 
+extern int NK_get_major_firmware_version(){
+  auto m = NitrokeyManager::instance();
+  return get_with_result([&](){
+      return m->get_major_firmware_version();
+  });
+}
+
 
 }
 

--- a/NK_C_API.h
+++ b/NK_C_API.h
@@ -324,7 +324,11 @@ extern int NK_erase_password_safe_slot(uint8_t slot_number);
  */
 extern int NK_is_AES_supported(const char *user_password);
 
-
+/**
+ * Get device's major firmware version
+ * @return 7,8 for Pro and major for Storage
+ */
+extern int NK_get_major_firmware_version();
 
 
 

--- a/NitrokeyManager.cc
+++ b/NitrokeyManager.cc
@@ -589,13 +589,12 @@ namespace nitrokey{
     }
 
     bool NitrokeyManager::is_authorization_command_supported(){
+      //authorization command is supported for versions equal or below:
         auto m = std::unordered_map<DeviceModel , int, EnumClassHash>({
                                                {DeviceModel::PRO, 7},
                                                {DeviceModel::STORAGE, 43},
          });
-      auto status_p = GetStatus::CommandTransaction::run(*device);
-      //FIXME use different function for checking storage firmware version
-      return status_p.data().firmware_version <= m[device->get_device_model()];
+        return get_major_firmware_version() <= m[device->get_device_model()];
     }
 
     int NitrokeyManager::get_major_firmware_version(){

--- a/NitrokeyManager.cc
+++ b/NitrokeyManager.cc
@@ -323,7 +323,6 @@ namespace nitrokey{
       auto payload2 = get_payload<stick10_08::SendOTPData>();
       strcpyT(payload2.temporary_admin_password, temporary_password);
       strcpyT(payload2.data, slot_name);
-      payload2.length = strlen((const char *) payload2.data);
       payload2.setTypeName();
       stick10_08::SendOTPData::CommandTransaction::run(*device, payload2);
 

--- a/NitrokeyManager.cc
+++ b/NitrokeyManager.cc
@@ -4,6 +4,7 @@
 #include "include/LibraryException.h"
 #include <algorithm>
 #include <unordered_map>
+#include <stick20_commands.h>
 #include "include/misc.h"
 
 namespace nitrokey{
@@ -589,7 +590,22 @@ namespace nitrokey{
                                                {DeviceModel::STORAGE, 43},
          });
       auto status_p = GetStatus::CommandTransaction::run(*device);
+      //FIXME use different function for checking storage firmware version
       return status_p.data().firmware_version <= m[device->get_device_model()];
+    }
+
+    int NitrokeyManager::get_major_firmware_version(){
+      switch(device->get_device_model()){
+        case DeviceModel::PRO:{
+          auto status_p = GetStatus::CommandTransaction::run(*device);
+          return status_p.data().firmware_version; //7 or 8
+        }
+        case DeviceModel::STORAGE:{
+          auto status = stick20::GetDeviceStatus::CommandTransaction::run(*device);
+          return status.data().versionInfo.major;
+        }
+      }
+      return 0;
     }
 
     bool NitrokeyManager::is_AES_supported(const char *user_password) {

--- a/NitrokeyManager.cc
+++ b/NitrokeyManager.cc
@@ -302,6 +302,10 @@ namespace nitrokey{
       payload2.id = 0;
       auto secret_bin = misc::hex_string_to_byte(secret);
       auto remaining_secret_length = secret_bin.size();
+      const auto maximum_OTP_secret_size = 40;
+      if(remaining_secret_length > maximum_OTP_secret_size){
+        throw TargetBufferSmallerThanSource(remaining_secret_length, maximum_OTP_secret_size);
+      }
 
       while (remaining_secret_length>0){
         const auto bytesToCopy = std::min(sizeof(payload2.data), remaining_secret_length);

--- a/command_id.cc
+++ b/command_id.cc
@@ -139,6 +139,9 @@ const char *commandid_to_string(CommandID id) {
       return "DETECT_SC_AES";
     case CommandID::NEW_AES_KEY:
       return "NEW_AES_KEY";
+    case CommandID::WRITE_TO_SLOT_2:
+      return "WRITE_TO_SLOT_2";
+      break;
   }
   return "UNKNOWN";
 }

--- a/command_id.cc
+++ b/command_id.cc
@@ -142,6 +142,9 @@ const char *commandid_to_string(CommandID id) {
     case CommandID::WRITE_TO_SLOT_2:
       return "WRITE_TO_SLOT_2";
       break;
+    case CommandID::SEND_OTP_DATA:
+      return "SEND_OTP_DATA";
+      break;
   }
   return "UNKNOWN";
 }

--- a/include/NitrokeyManager.h
+++ b/include/NitrokeyManager.h
@@ -110,6 +110,10 @@ namespace nitrokey {
         int get_progress_bar_value();
 
         ~NitrokeyManager();
+        bool is_authorization_command_supported();
+
+        template <typename S, typename A, typename T>
+        void authorize_packet(T &package, const char *admin_temporary_password, shared_ptr<Device> device);
     private:
         NitrokeyManager();
 

--- a/include/NitrokeyManager.h
+++ b/include/NitrokeyManager.h
@@ -5,6 +5,7 @@
 #include "log.h"
 #include "device_proto.h"
 #include "stick10_commands.h"
+#include "stick10_commands_0.8.h"
 #include "stick20_commands.h"
 #include <vector>
 #include <memory>
@@ -132,6 +133,21 @@ namespace nitrokey {
         template <typename ProCommand, PasswordKind StoKind>
         void change_PIN_general(char *current_PIN, char *new_PIN);
 
+        void write_HOTP_slot_authorize(uint8_t slot_number, const char *slot_name, const char *secret, uint64_t hotp_counter,
+                                   bool use_8_digits, bool use_enter, bool use_tokenID, const char *token_ID,
+                                   const char *temporary_password);
+
+        void write_HOTP_slot_no_authorize(uint8_t slot_number, const char *slot_name, const char *secret, uint64_t hotp_counter,
+                                      bool use_8_digits, bool use_enter, bool use_tokenID, const char *token_ID,
+                                      const char *temporary_password) const;
+
+        void write_TOTP_slot_authorize(uint8_t slot_number, const char *slot_name, const char *secret, uint16_t time_window,
+                                   bool use_8_digits, bool use_enter, bool use_tokenID, const char *token_ID,
+                                   const char *temporary_password);
+
+        void write_TOTP_slot_no_authorize(uint8_t slot_number, const char *slot_name, const char *secret, uint16_t time_window,
+                                      bool use_8_digits, bool use_enter, bool use_tokenID, const char *token_ID,
+                                      const char *temporary_password) const;
     };
 }
 

--- a/include/NitrokeyManager.h
+++ b/include/NitrokeyManager.h
@@ -115,6 +115,8 @@ namespace nitrokey {
 
         template <typename S, typename A, typename T>
         void authorize_packet(T &package, const char *admin_temporary_password, shared_ptr<Device> device);
+        int get_major_firmware_version();
+
     private:
         NitrokeyManager();
 
@@ -145,6 +147,7 @@ namespace nitrokey {
                                          uint64_t counter_or_interval,
                                          bool use_8_digits, bool use_enter, bool use_tokenID, const char *token_ID,
                                          const char *temporary_password) const;
+
     };
 }
 

--- a/include/NitrokeyManager.h
+++ b/include/NitrokeyManager.h
@@ -137,17 +137,14 @@ namespace nitrokey {
                                    bool use_8_digits, bool use_enter, bool use_tokenID, const char *token_ID,
                                    const char *temporary_password);
 
-        void write_HOTP_slot_no_authorize(uint8_t slot_number, const char *slot_name, const char *secret, uint64_t hotp_counter,
-                                      bool use_8_digits, bool use_enter, bool use_tokenID, const char *token_ID,
-                                      const char *temporary_password) const;
-
         void write_TOTP_slot_authorize(uint8_t slot_number, const char *slot_name, const char *secret, uint16_t time_window,
                                    bool use_8_digits, bool use_enter, bool use_tokenID, const char *token_ID,
                                    const char *temporary_password);
 
-        void write_TOTP_slot_no_authorize(uint8_t slot_number, const char *slot_name, const char *secret, uint16_t time_window,
-                                      bool use_8_digits, bool use_enter, bool use_tokenID, const char *token_ID,
-                                      const char *temporary_password) const;
+        void write_OTP_slot_no_authorize(uint8_t internal_slot_number, const char *slot_name, const char *secret,
+                                         uint64_t counter_or_interval,
+                                         bool use_8_digits, bool use_enter, bool use_tokenID, const char *token_ID,
+                                         const char *temporary_password) const;
     };
 }
 

--- a/include/command_id.h
+++ b/include/command_id.h
@@ -65,6 +65,7 @@ enum class CommandID : uint8_t {
   FACTORY_RESET = 0x13,
   CHANGE_USER_PIN = 0x14,
   CHANGE_ADMIN_PIN = 0x15,
+  WRITE_TO_SLOT_2 = 0x16,
 
   ENABLE_CRYPTED_PARI = 0x20,
   DISABLE_CRYPTED_PARI = 0x20 + 1, //@unused

--- a/include/command_id.h
+++ b/include/command_id.h
@@ -66,6 +66,7 @@ enum class CommandID : uint8_t {
   CHANGE_USER_PIN = 0x14,
   CHANGE_ADMIN_PIN = 0x15,
   WRITE_TO_SLOT_2 = 0x16,
+  SEND_OTP_DATA = 0x17,
 
   ENABLE_CRYPTED_PARI = 0x20,
   DISABLE_CRYPTED_PARI = 0x20 + 1, //@unused

--- a/include/device.h
+++ b/include/device.h
@@ -12,6 +12,15 @@ namespace nitrokey {
 namespace device {
     using namespace std::chrono_literals;
 
+    struct EnumClassHash
+    {
+        template <typename T>
+        std::size_t operator()(T t) const
+        {
+          return static_cast<std::size_t>(t);
+        }
+    };
+
 enum class DeviceModel{
     PRO,
     STORAGE

--- a/include/stick10_commands.h
+++ b/include/stick10_commands.h
@@ -48,6 +48,7 @@ class EraseSlot : Command<CommandID::ERASE_SLOT> {
  public:
   struct CommandPayload {
     uint8_t slot_number;
+      uint8_t temporary_admin_password[25];
 
     bool isValid() const { return !(slot_number & 0xF0); }
       std::string dissect() const {
@@ -137,6 +138,7 @@ class WriteToHOTPSlot : Command<CommandID::WRITE_TO_SLOT> {
 };
 
 class WriteToTOTPSlot : Command<CommandID::WRITE_TO_SLOT> {
+	//admin auth
  public:
   struct CommandPayload {
     uint8_t slot_number;
@@ -182,6 +184,7 @@ class WriteToTOTPSlot : Command<CommandID::WRITE_TO_SLOT> {
 };
 
 class GetTOTP : Command<CommandID::GET_CODE> {
+	//user auth
  public:
   struct CommandPayload {
     uint8_t slot_number;
@@ -612,6 +615,7 @@ class PasswordSafeSendSlotViaHID : Command<CommandID::PW_SAFE_SEND_DATA> {
 // TODO "Device::passwordSafeSendSlotDataViaHID"
 
 class WriteGeneralConfig : Command<CommandID::WRITE_CONFIG> {
+	//admin auth
  public:
   struct CommandPayload {
     union{

--- a/include/stick10_commands.h
+++ b/include/stick10_commands.h
@@ -48,7 +48,6 @@ class EraseSlot : Command<CommandID::ERASE_SLOT> {
  public:
   struct CommandPayload {
     uint8_t slot_number;
-      uint8_t temporary_admin_password[25];
 
     bool isValid() const { return !(slot_number & 0xF0); }
       std::string dissect() const {
@@ -138,7 +137,6 @@ class WriteToHOTPSlot : Command<CommandID::WRITE_TO_SLOT> {
 };
 
 class WriteToTOTPSlot : Command<CommandID::WRITE_TO_SLOT> {
-	//admin auth
  public:
   struct CommandPayload {
     uint8_t slot_number;
@@ -184,7 +182,6 @@ class WriteToTOTPSlot : Command<CommandID::WRITE_TO_SLOT> {
 };
 
 class GetTOTP : Command<CommandID::GET_CODE> {
-	//user auth
  public:
   struct CommandPayload {
     uint8_t slot_number;
@@ -615,7 +612,6 @@ class PasswordSafeSendSlotViaHID : Command<CommandID::PW_SAFE_SEND_DATA> {
 // TODO "Device::passwordSafeSendSlotDataViaHID"
 
 class WriteGeneralConfig : Command<CommandID::WRITE_CONFIG> {
-	//admin auth
  public:
   struct CommandPayload {
     union{

--- a/include/stick10_commands_0.8.h
+++ b/include/stick10_commands_0.8.h
@@ -252,9 +252,9 @@ namespace nitrokey {
                 struct CommandPayload {
                     uint8_t temporary_user_password[25];
                     uint8_t slot_number;
-                    uint64_t challenge;
-                    uint64_t last_totp_time;
-                    uint8_t last_interval;
+                    uint64_t challenge; //@unused
+                    uint64_t last_totp_time; //@unused
+                    uint8_t last_interval; //@unused
 
                     bool isValid() const { return !(slot_number & 0xF0); }
                     std::string dissect() const {

--- a/include/stick10_commands_0.8.h
+++ b/include/stick10_commands_0.8.h
@@ -12,6 +12,7 @@
 #include "inttypes.h"
 #include "command.h"
 #include "device_proto.h"
+#include "stick10_commands.h"
 
 namespace nitrokey {
     namespace proto {
@@ -20,6 +21,8 @@ namespace nitrokey {
  *	Stick10 protocol definition
  */
         namespace stick10_08 {
+            using stick10::FirstAuthenticate;
+            using stick10::UserAuthenticate;
 
             class EraseSlot : Command<CommandID::ERASE_SLOT> {
             public:
@@ -117,20 +120,68 @@ namespace nitrokey {
                     CommandTransaction;
             };
 
+            class GetHOTP : Command<CommandID::GET_CODE> {
+            public:
+                struct CommandPayload {
+                    uint8_t temporary_user_password[25];
+                    uint8_t slot_number;
+
+                    bool isValid() const { return (slot_number & 0xF0); }
+                    std::string dissect() const {
+                      std::stringstream ss;
+                      ss << "temporary_user_password:\t" << temporary_user_password << std::endl;
+                      ss << "slot_number:\t" << (int)(slot_number) << std::endl;
+                      return ss.str();
+                    }
+                } __packed;
+
+                struct ResponsePayload {
+                    union {
+                        uint8_t whole_response[18]; //14 bytes reserved for config, but used only 1
+                        struct {
+                            uint32_t code;
+                            union{
+                                uint8_t _slot_config;
+                                struct{
+                                    bool use_8_digits   : 1;
+                                    bool use_enter      : 1;
+                                    bool use_tokenID    : 1;
+                                };
+                            };
+                        } __packed;
+                    } __packed;
+
+                    bool isValid() const { return true; }
+                    std::string dissect() const {
+                      std::stringstream ss;
+                      ss << "code:\t" << (code) << std::endl;
+                      ss << "slot_config:\t" << std::bitset<8>((int)_slot_config) << std::endl;
+                      ss << "\tuse_8_digits(0):\t" << use_8_digits << std::endl;
+                      ss << "\tuse_enter(1):\t" << use_enter << std::endl;
+                      ss << "\tuse_tokenID(2):\t" << use_tokenID << std::endl;
+                      return ss.str();
+                    }
+                } __packed;
+
+                typedef Transaction<command_id(), struct CommandPayload, struct ResponsePayload>
+                    CommandTransaction;
+            };
+
 
             class GetTOTP : Command<CommandID::GET_CODE> {
                 //user auth
             public:
                 struct CommandPayload {
+                    uint8_t temporary_user_password[25];
                     uint8_t slot_number;
                     uint64_t challenge;
                     uint64_t last_totp_time;
                     uint8_t last_interval;
-                    uint8_t user_temporary_password[25];
 
                     bool isValid() const { return !(slot_number & 0xF0); }
                     std::string dissect() const {
                       std::stringstream ss;
+                      ss << "temporary_user_password:\t" << temporary_user_password << std::endl;
                       ss << "slot_number:\t" << (int)(slot_number) << std::endl;
                       ss << "challenge:\t" << (challenge) << std::endl;
                       ss << "last_totp_time:\t" << (last_totp_time) << std::endl;
@@ -172,6 +223,36 @@ namespace nitrokey {
             };
 
 
+            class WriteGeneralConfig : Command<CommandID::WRITE_CONFIG> {
+                //admin auth
+            public:
+                struct CommandPayload {
+                    union{
+                        uint8_t config[5];
+                        struct{
+                            uint8_t numlock;     /** 0-1: HOTP slot number from which the code will be get on double press, other value - function disabled */
+                            uint8_t capslock;    /** same as numlock */
+                            uint8_t scrolllock;  /** same as numlock */
+                            uint8_t enable_user_password;
+                            uint8_t delete_user_password;
+                        };
+                    };
+                    uint8_t temporary_admin_password[25];
+
+                    std::string dissect() const {
+                      std::stringstream ss;
+                      ss << "numlock:\t" << (int)numlock << std::endl;
+                      ss << "capslock:\t" << (int)capslock << std::endl;
+                      ss << "scrolllock:\t" << (int)scrolllock << std::endl;
+                      ss << "enable_user_password:\t" << (bool) enable_user_password << std::endl;
+                      ss << "delete_user_password:\t" << (bool) delete_user_password << std::endl;
+                      return ss.str();
+                    }
+                } __packed;
+
+                typedef Transaction<command_id(), struct CommandPayload, struct EmptyPayload>
+                    CommandTransaction;
+            };
         }
     }
 }

--- a/include/stick10_commands_0.8.h
+++ b/include/stick10_commands_0.8.h
@@ -201,8 +201,13 @@ namespace nitrokey {
             class GetHOTP : Command<CommandID::GET_CODE> {
             public:
                 struct CommandPayload {
-                    uint8_t temporary_user_password[25];
                     uint8_t slot_number;
+                    struct {
+                        uint64_t challenge; //@unused
+                        uint64_t last_totp_time; //@unused
+                        uint8_t last_interval; //@unused
+                    } __packed _unused;
+                    uint8_t temporary_user_password[25];
 
                     bool isValid() const { return (slot_number & 0xF0); }
                     std::string dissect() const {
@@ -250,11 +255,11 @@ namespace nitrokey {
                 //user auth
             public:
                 struct CommandPayload {
-                    uint8_t temporary_user_password[25];
                     uint8_t slot_number;
                     uint64_t challenge; //@unused
                     uint64_t last_totp_time; //@unused
                     uint8_t last_interval; //@unused
+                    uint8_t temporary_user_password[25];
 
                     bool isValid() const { return !(slot_number & 0xF0); }
                     std::string dissect() const {

--- a/include/stick10_commands_0.8.h
+++ b/include/stick10_commands_0.8.h
@@ -24,6 +24,7 @@ namespace nitrokey {
             using stick10::FirstAuthenticate;
             using stick10::UserAuthenticate;
             using stick10::SetTime;
+            using stick10::GetStatus;
 
             class EraseSlot : Command<CommandID::ERASE_SLOT> {
             public:

--- a/include/stick10_commands_0.8.h
+++ b/include/stick10_commands_0.8.h
@@ -1,0 +1,178 @@
+//
+// Created by sz on 08.11.16.
+//
+
+#ifndef LIBNITROKEY_STICK10_COMMANDS_0_8_H
+#define LIBNITROKEY_STICK10_COMMANDS_0_8_H
+
+#include <bitset>
+#include <iomanip>
+#include <string>
+#include <sstream>
+#include "inttypes.h"
+#include "command.h"
+#include "device_proto.h"
+
+namespace nitrokey {
+    namespace proto {
+
+/*
+ *	Stick10 protocol definition
+ */
+        namespace stick10_08 {
+
+            class EraseSlot : Command<CommandID::ERASE_SLOT> {
+            public:
+                struct CommandPayload {
+                    uint8_t slot_number;
+                    uint8_t temporary_admin_password[25];
+
+                    bool isValid() const { return !(slot_number & 0xF0); }
+                    std::string dissect() const {
+                      std::stringstream ss;
+                      ss << "slot_number:\t" << (int)(slot_number) << std::endl;
+                      return ss.str();
+                    }
+                } __packed;
+
+                typedef Transaction<command_id(), struct CommandPayload, struct EmptyPayload>
+                    CommandTransaction;
+            };
+
+            class WriteToHOTPSlot : Command<CommandID::WRITE_TO_SLOT> {
+                //admin auth
+            public:
+                struct CommandPayload {
+                    uint8_t temporary_admin_password[25];
+                    uint8_t slot_secret[20];
+                    union {
+                        uint8_t _slot_config;
+                        struct {
+                            bool use_8_digits   : 1;
+                            bool use_enter      : 1;
+                            bool use_tokenID    : 1;
+                        };
+                    };
+                    union {
+                        uint8_t slot_token_id[13]; /** OATH Token Identifier */
+                        struct { /** @see https://openauthentication.org/token-specs/ */
+                            uint8_t omp[2];
+                            uint8_t tt[2];
+                            uint8_t mui[8];
+                            uint8_t keyboard_layout; //disabled feature in nitroapp as of 20160805
+                        } slot_token_fields;
+                    };
+
+                    bool isValid() const { return true; }
+
+                    std::string dissect() const {
+                      std::stringstream ss;
+                      ss << "temporary_admin_password:\t" << temporary_admin_password << std::endl;
+                      ss << "slot_secret:" << std::endl
+                         << ::nitrokey::misc::hexdump((const char *) (&slot_secret), sizeof slot_secret);
+                      ss << "slot_config:\t" << std::bitset<8>((int) _slot_config) << std::endl;
+                      ss << "\tuse_8_digits(0):\t" << use_8_digits << std::endl;
+                      ss << "\tuse_enter(1):\t" << use_enter << std::endl;
+                      ss << "\tuse_tokenID(2):\t" << use_tokenID << std::endl;
+
+                      ss << "slot_token_id:\t";
+                      for (auto i : slot_token_id)
+                        ss << std::hex << std::setw(2) << std::setfill('0') << (int) i << " ";
+                      ss << std::endl;
+
+                      return ss.str();
+                    }
+                } __packed;
+
+                typedef Transaction<command_id(), struct CommandPayload, struct EmptyPayload>
+                    CommandTransaction;
+            };
+
+            class WriteToHOTPSlot_2 : Command<CommandID::WRITE_TO_SLOT_2> {
+            public:
+                struct CommandPayload {
+                    uint8_t temporary_admin_password[25];
+                    uint8_t slot_number;
+                    uint8_t slot_name[15];
+                    union {
+                        uint64_t slot_counter;
+                        uint8_t slot_counter_s[8];
+                    } __packed;
+
+                    bool isValid() const { return !(slot_number & 0xF0); }
+
+                    std::string dissect() const {
+                      std::stringstream ss;
+                      ss << "temporary_admin_password:\t" << temporary_admin_password << std::endl;
+                      ss << "slot_number:\t" << (int) (slot_number) << std::endl;
+                      ss << "slot_name:\t" << slot_name << std::endl;
+                      ss << "slot_counter:\t[" << (int) slot_counter << "]\t"
+                         << ::nitrokey::misc::hexdump((const char *) (&slot_counter), sizeof slot_counter, false);
+
+                      return ss.str();
+                    }
+                } __packed;
+
+                typedef Transaction<command_id(), struct CommandPayload, struct EmptyPayload>
+                    CommandTransaction;
+            };
+
+
+            class GetTOTP : Command<CommandID::GET_CODE> {
+                //user auth
+            public:
+                struct CommandPayload {
+                    uint8_t slot_number;
+                    uint64_t challenge;
+                    uint64_t last_totp_time;
+                    uint8_t last_interval;
+                    uint8_t user_temporary_password[25];
+
+                    bool isValid() const { return !(slot_number & 0xF0); }
+                    std::string dissect() const {
+                      std::stringstream ss;
+                      ss << "slot_number:\t" << (int)(slot_number) << std::endl;
+                      ss << "challenge:\t" << (challenge) << std::endl;
+                      ss << "last_totp_time:\t" << (last_totp_time) << std::endl;
+                      ss << "last_interval:\t" << (int)(last_interval) << std::endl;
+                      return ss.str();
+                    }
+                } __packed;
+
+                struct ResponsePayload {
+                    union {
+                        uint8_t whole_response[18]; //14 bytes reserved for config, but used only 1
+                        struct {
+                            uint32_t code;
+                            union{
+                                uint8_t _slot_config;
+                                struct{
+                                    bool use_8_digits   : 1;
+                                    bool use_enter      : 1;
+                                    bool use_tokenID    : 1;
+                                };
+                            };
+                        } __packed ;
+                    } __packed ;
+
+                    bool isValid() const { return true; }
+                    std::string dissect() const {
+                      std::stringstream ss;
+                      ss << "code:\t" << (code) << std::endl;
+                      ss << "slot_config:\t" << std::bitset<8>((int)_slot_config) << std::endl;
+                      ss << "\tuse_8_digits(0):\t" << use_8_digits << std::endl;
+                      ss << "\tuse_enter(1):\t" << use_enter << std::endl;
+                      ss << "\tuse_tokenID(2):\t" << use_tokenID << std::endl;
+                      return ss.str();
+                    }
+                } __packed;
+
+                typedef Transaction<command_id(), struct CommandPayload, struct ResponsePayload>
+                    CommandTransaction;
+            };
+
+
+        }
+    }
+}
+#endif //LIBNITROKEY_STICK10_COMMANDS_0_8_H

--- a/include/stick10_commands_0.8.h
+++ b/include/stick10_commands_0.8.h
@@ -51,7 +51,6 @@ namespace nitrokey {
                     uint8_t temporary_admin_password[25];
                     uint8_t type; //0-secret, 1-name
                     uint8_t id; //multiple reports for values longer than 30 bytes
-                    uint8_t length; //data length
                     uint8_t data[30]; //data, does not need null termination
 
                     bool isValid() const { return true; }
@@ -68,7 +67,6 @@ namespace nitrokey {
                       ss << "temporary_admin_password:\t" << temporary_admin_password << std::endl;
                       ss << "type:\t" << type << std::endl;
                       ss << "id:\t" << (int)id << std::endl;
-                      ss << "length:\t" << (int)length << std::endl;
                       ss << "data:" << std::endl
                          << ::nitrokey::misc::hexdump((const char *) (&data), sizeof data);
                       return ss.str();

--- a/include/stick10_commands_0.8.h
+++ b/include/stick10_commands_0.8.h
@@ -75,7 +75,23 @@ namespace nitrokey {
                     }
                 } __packed;
 
-                typedef Transaction<command_id(), struct CommandPayload, struct EmptyPayload>
+
+                struct ResponsePayload {
+                    union {
+                        uint8_t data[40];
+                    } __packed;
+
+                    bool isValid() const { return true; }
+                    std::string dissect() const {
+                      std::stringstream ss;
+                      ss << "data:" << std::endl
+                         << ::nitrokey::misc::hexdump((const char *) (&data), sizeof data);
+                      return ss.str();
+                    }
+                } __packed;
+
+
+                typedef Transaction<command_id(), struct CommandPayload, struct ResponsePayload>
                     CommandTransaction;
             };
 

--- a/include/stick10_commands_0.8.h
+++ b/include/stick10_commands_0.8.h
@@ -49,7 +49,7 @@ namespace nitrokey {
             public:
                 struct CommandPayload {
                     uint8_t temporary_admin_password[25];
-                    uint8_t type; //0-secret, 1-name
+                    uint8_t type; //S-secret, N-name
                     uint8_t id; //multiple reports for values longer than 30 bytes
                     uint8_t data[30]; //data, does not need null termination
 

--- a/include/stick10_commands_0.8.h
+++ b/include/stick10_commands_0.8.h
@@ -25,6 +25,27 @@ namespace nitrokey {
             using stick10::UserAuthenticate;
             using stick10::SetTime;
             using stick10::GetStatus;
+            using stick10::BuildAESKey;
+            using stick10::ChangeAdminPin;
+            using stick10::ChangeUserPin;
+            using stick10::EnablePasswordSafe;
+            using stick10::ErasePasswordSafeSlot;
+            using stick10::FactoryReset;
+            using stick10::GetPasswordRetryCount;
+            using stick10::GetUserPasswordRetryCount;
+            using stick10::GetPasswordSafeSlotLogin;
+            using stick10::GetPasswordSafeSlotName;
+            using stick10::GetPasswordSafeSlotPassword;
+            using stick10::GetPasswordSafeSlotStatus;
+            using stick10::GetSlotName;
+            using stick10::IsAESSupported;
+            using stick10::LockDevice;
+            using stick10::PasswordSafeInitKey;
+            using stick10::PasswordSafeSendSlotViaHID;
+            using stick10::SetPasswordSafeSlotData;
+            using stick10::SetPasswordSafeSlotData2;
+            using stick10::UnlockUserPassword;
+            using stick10::ReadSlot;
 
             class EraseSlot : Command<CommandID::ERASE_SLOT> {
             public:

--- a/include/stick20_commands.h
+++ b/include/stick20_commands.h
@@ -125,7 +125,17 @@ namespace nitrokey {
                     uint16_t MagicNumber_StickConfig_u16;
                     uint8_t ReadWriteFlagUncryptedVolume_u8;
                     uint8_t ReadWriteFlagCryptedVolume_u8;
+
+                    union{
                     uint8_t VersionInfo_au8[4];
+                        struct {
+                            uint8_t __unused;
+                            uint8_t major;
+                            uint8_t __unused2;
+                            uint8_t minor;
+                        } __packed versionInfo;
+                    };
+
                     uint8_t ReadWriteFlagHiddenVolume_u8;
                     uint8_t FirmwareLocked_u8;
                     uint8_t NewSDCardFound_u8;

--- a/misc.cc
+++ b/misc.cc
@@ -16,7 +16,8 @@ std::vector<uint8_t> hex_string_to_byte(const char* hexString){
     if (s_size%2!=0 || s_size==0 || s_size>big_string_size){
         throw InvalidHexString(0);
     }
-    auto data = std::vector<uint8_t>(d_size, 0);
+    auto data = std::vector<uint8_t>();
+    data.reserve(d_size);
 
     char buf[2];
     for(int i=0; i<s_size; i++){
@@ -28,7 +29,7 @@ std::vector<uint8_t> hex_string_to_byte(const char* hexString){
         }
         buf[i%2] = c;
         if (i%2==1){
-            data[i/2] = strtoul(buf, NULL, 16) & 0xFF;
+            data.push_back( strtoul(buf, NULL, 16) & 0xFF );
         }
     }
     return data;

--- a/misc.cc
+++ b/misc.cc
@@ -13,7 +13,7 @@ std::vector<uint8_t> hex_string_to_byte(const char* hexString){
     const size_t big_string_size = 256; //arbitrary 'big' number
     const size_t s_size = strlen(hexString);
     const size_t d_size = s_size/2;
-    if (s_size%2!=0 || s_size==0 || s_size>big_string_size){
+    if (s_size%2!=0 || s_size>big_string_size){
         throw InvalidHexString(0);
     }
     auto data = std::vector<uint8_t>();

--- a/unittest/conftest.py
+++ b/unittest/conftest.py
@@ -2,6 +2,16 @@ import pytest
 
 from misc import ffi
 
+device_type = None
+
+def skip_if_device_version_lower_than(allowed_devices):
+    global device_type
+    model, version = device_type
+    infinite_version_number = 999
+    if allowed_devices.get(model, infinite_version_number) > version:
+        pytest.skip('This device model is not applicable to run this test')
+
+
 @pytest.fixture(scope="module")
 def C(request):
     fp = '../NK_C_API.h'
@@ -24,7 +34,11 @@ def C(request):
     nk_login = C.NK_login_auto()
     if nk_login != 1:
         print('No devices detected!')
-    assert nk_login == 1  # returns 0 if not connected or wrong model or 1 when connected
+    assert nk_login != 0  # returns 0 if not connected or wrong model or 1 when connected
+    global device_type
+    firmware_version = C.NK_get_major_firmware_version()
+    model = 'P' if firmware_version in [7,8] else 'S'
+    device_type = (model, firmware_version)
 
     # assert C.NK_first_authenticate(DefaultPasswords.ADMIN, DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
     # assert C.NK_user_authenticate(DefaultPasswords.USER, DefaultPasswords.USER_TEMP) == DeviceErrorCode.STATUS_OK

--- a/unittest/constants.py
+++ b/unittest/constants.py
@@ -2,7 +2,7 @@ from enum import Enum
 from misc import to_hex
 
 RFC_SECRET_HR = '12345678901234567890'
-RFC_SECRET = to_hex(RFC_SECRET_HR)  # '3031323334353637383930...'
+RFC_SECRET = to_hex(RFC_SECRET_HR)  # '31323334353637383930...'
 
 
 # print( repr((RFC_SECRET, RFC_SECRET_, len(RFC_SECRET))) )

--- a/unittest/constants.py
+++ b/unittest/constants.py
@@ -2,7 +2,7 @@ from enum import Enum
 from misc import to_hex
 
 RFC_SECRET_HR = '12345678901234567890'
-RFC_SECRET = to_hex(RFC_SECRET_HR)  # '12345678901234567890'
+RFC_SECRET = to_hex(RFC_SECRET_HR)  # '3031323334353637383930...'
 
 
 # print( repr((RFC_SECRET, RFC_SECRET_, len(RFC_SECRET))) )

--- a/unittest/misc.py
+++ b/unittest/misc.py
@@ -31,6 +31,10 @@ def is_pro_rtm_07(C):
     firmware = get_firmware_version_from_status(C)
     return '07 00' in firmware
 
+def is_pro_rtm_08(C):
+    firmware = get_firmware_version_from_status(C)
+    return '08 00' in firmware
+
 
 def is_storage(C):
     """

--- a/unittest/misc.py
+++ b/unittest/misc.py
@@ -20,25 +20,29 @@ def cast_pointer_to_tuple(obj, typen, len):
     #     config = cast_pointer_to_tuple(config_raw_data, 'uint8_t', 5)
     return tuple(ffi.cast("%s [%d]" % (typen, len), obj)[0:len])
 
-def get_firmware_version_from_status(C):
-    status = gs(C.NK_status())
-    status = [s if 'firmware_version' in s else '' for s in status.split('\n')]
-    firmware = status[0].split(':')[1]
+
+def get_devices_firmware_version(C):
+    firmware = C.NK_get_major_firmware_version()
     return firmware
 
 
 def is_pro_rtm_07(C):
-    firmware = get_firmware_version_from_status(C)
-    return '07 00' in firmware
+    firmware = get_devices_firmware_version(C)
+    return firmware == 7
+
 
 def is_pro_rtm_08(C):
-    firmware = get_firmware_version_from_status(C)
-    return '08 00' in firmware
+    firmware = get_devices_firmware_version(C)
+    return firmware == 8
 
 
 def is_storage(C):
     """
     exact firmware storage is sent by other function
     """
-    firmware = get_firmware_version_from_status(C)
-    return '01 00' in firmware
+    # TODO identify connected device directly
+    return not is_pro_rtm_08(C) and not is_pro_rtm_07(C)
+
+
+def is_long_OTP_secret_handled(C):
+    return is_pro_rtm_08(C) or is_storage(C) and get_devices_firmware_version(C) > 43

--- a/unittest/requirements.txt
+++ b/unittest/requirements.txt
@@ -1,0 +1,4 @@
+cffi
+pytest-repeat
+pytest-randomly
+enum

--- a/unittest/test3.cc
+++ b/unittest/test3.cc
@@ -148,6 +148,13 @@ TEST_CASE("authorize user HOTP", "[pronew]") {
 
 }
 
+TEST_CASE("check firmware version", "[pronew]") {
+  Stick10 stick;
+  connect_and_setup(stick);
+
+  auto p = GetStatus::CommandTransaction::run(stick);
+  REQUIRE(p.data().firmware_version == 8);
+}
 
 TEST_CASE("authorize user TOTP", "[pronew]") {
   Stick10 stick;

--- a/unittest/test3.cc
+++ b/unittest/test3.cc
@@ -1,0 +1,78 @@
+//
+// Created by sz on 08.11.16.
+//
+
+#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main()
+
+static const char *const default_admin_pin = "12345678";
+static const char *const default_user_pin = "123456";
+const char * temporary_password = "123456789012345678901234";
+const char * RFC_SECRET = "12345678901234567890";
+
+#include "catch.hpp"
+
+#include <iostream>
+#include <string.h>
+#include <NitrokeyManager.h>
+#include "device_proto.h"
+#include "log.h"
+#include "stick10_commands.h"
+#include "stick10_commands_0.8.h"
+//#include "stick20_commands.h"
+
+using namespace std;
+using namespace nitrokey::device;
+using namespace nitrokey::proto;
+//using namespace nitrokey::proto::stick10_08;
+using namespace nitrokey::proto::stick10;
+using namespace nitrokey::log;
+using namespace nitrokey::misc;
+
+void connect_and_setup(Stick10 &stick) {
+  bool connected = stick.connect();
+  REQUIRE(connected == true);
+  Log::instance().set_loglevel(Loglevel::DEBUG);
+}
+
+void authorize(Stick10 &stick) {
+  auto authreq = get_payload<FirstAuthenticate>();
+  strcpy((char *) (authreq.card_password), default_admin_pin);
+  strcpy((char *) (authreq.temporary_password), temporary_password);
+  FirstAuthenticate::CommandTransaction::run(stick, authreq);
+}
+
+TEST_CASE("write slot", "[pronew]"){
+  Stick10 stick;
+  connect_and_setup(stick);
+
+  auto p = get_payload<stick10_08::WriteToHOTPSlot>();
+//  p.slot_number = 0 + 0x10;
+  strcpyT(p.slot_secret, RFC_SECRET);
+  strcpyT(p.temporary_admin_password, temporary_password);
+  p.use_8_digits = true;
+  stick10_08::WriteToHOTPSlot::CommandTransaction::run(stick, p);
+
+  auto p2 = get_payload<stick10_08::WriteToHOTPSlot_2>();
+  strcpyT(p2.temporary_admin_password, temporary_password);
+  p2.slot_number = 0 + 0x10;
+  p2.slot_counter = 0;
+  strcpyT(p2.slot_name, "test name aaa");
+  stick10_08::WriteToHOTPSlot_2::CommandTransaction::run(stick, p2);
+
+  auto p3 = get_payload<GetHOTP>();
+  p3.slot_number = 0 + 0x10;
+  GetHOTP::CommandTransaction::run(stick, p3);
+  
+}
+
+
+TEST_CASE("erase slot", "[pronew]"){
+  Stick10 stick;
+  connect_and_setup(stick);
+  authorize(stick);
+
+  auto erase_payload = get_payload<stick10_08::EraseSlot>();
+  erase_payload.slot_number = 1 + 0x10;
+  strcpyT(erase_payload.temporary_admin_password, temporary_password);
+  stick10_08::EraseSlot::CommandTransaction::run(stick, erase_payload);
+}

--- a/unittest/test3.cc
+++ b/unittest/test3.cc
@@ -48,18 +48,23 @@ TEST_CASE("write slot", "[pronew]"){
   Stick10 stick;
   connect_and_setup(stick);
 
-  auto p = get_payload<stick10_08::WriteToHOTPSlot>();
+  auto p = get_payload<WriteToHOTPSlot>();
   strcpyT(p.slot_secret, RFC_SECRET);
   strcpyT(p.temporary_admin_password, temporary_password);
   p.use_8_digits = true;
   stick10_08::WriteToHOTPSlot::CommandTransaction::run(stick, p);
 
-  auto p2 = get_payload<stick10_08::WriteToHOTPSlot_2>();
+  auto p2 = get_payload<WriteToHOTPSlot_2>();
   strcpyT(p2.temporary_admin_password, temporary_password);
   p2.slot_number = 0 + 0x10;
   p2.slot_counter = 0;
   strcpyT(p2.slot_name, "test name aaa");
   stick10_08::WriteToHOTPSlot_2::CommandTransaction::run(stick, p2);
+
+  auto pc = get_payload<WriteGeneralConfig>();
+  pc.enable_user_password = 0;
+  strcpyT(pc.temporary_admin_password, temporary_password);
+  WriteGeneralConfig::CommandTransaction::run(stick, pc);
 
   auto p3 = get_payload<GetHOTP>();
   p3.slot_number = 0 + 0x10;
@@ -73,14 +78,19 @@ TEST_CASE("erase slot", "[pronew]"){
   connect_and_setup(stick);
   authorize(stick);
 
+  auto p = get_payload<WriteGeneralConfig>();
+  p.enable_user_password = 0;
+  strcpyT(p.temporary_admin_password, temporary_password);
+  WriteGeneralConfig::CommandTransaction::run(stick, p);
+
   auto p3 = get_payload<GetHOTP>();
   p3.slot_number = 0 + 0x10;
   GetHOTP::CommandTransaction::run(stick, p3);
 
-  auto erase_payload = get_payload<stick10_08::EraseSlot>();
+  auto erase_payload = get_payload<EraseSlot>();
   erase_payload.slot_number = 0 + 0x10;
   strcpyT(erase_payload.temporary_admin_password, temporary_password);
-  stick10_08::EraseSlot::CommandTransaction::run(stick, erase_payload);
+  EraseSlot::CommandTransaction::run(stick, erase_payload);
 
   auto p4 = get_payload<GetHOTP>();
   p4.slot_number = 0 + 0x10;
@@ -133,7 +143,7 @@ TEST_CASE("authorize user HOTP", "[pronew]") {
   );
   strcpyT(p3.temporary_user_password, temporary_password);
   auto code_response = GetHOTP::CommandTransaction::run(stick, p3);
-  REQUIRE(code_response.data().code == 1284755224);
+  REQUIRE(code_response.data().code == 84755224);
 
 }
 

--- a/unittest/test3.cc
+++ b/unittest/test3.cc
@@ -47,6 +47,7 @@ void authorize(Stick10 &stick) {
 TEST_CASE("write slot", "[pronew]"){
   Stick10 stick;
   connect_and_setup(stick);
+  authorize(stick);
 
   auto p = get_payload<WriteToHOTPSlot>();
   strcpyT(p.slot_secret, RFC_SECRET);

--- a/unittest/test3.cc
+++ b/unittest/test3.cc
@@ -53,13 +53,11 @@ TEST_CASE("write slot", "[pronew]"){
   strcpyT(p2.temporary_admin_password, temporary_password);
   p2.setTypeName();
   strcpyT(p2.data, "test name aaa");
-  p2.length = strlen((const char *) p2.data);
   stick10_08::SendOTPData::CommandTransaction::run(stick, p2);
 
   p2 = get_payload<SendOTPData>();
   strcpyT(p2.temporary_admin_password, temporary_password);
   strcpyT(p2.data, RFC_SECRET);
-  p2.length = strlen(RFC_SECRET);
   p2.setTypeSecret();
   stick10_08::SendOTPData::CommandTransaction::run(stick, p2);
 
@@ -138,13 +136,11 @@ TEST_CASE("authorize user HOTP", "[pronew]") {
   strcpyT(p2.temporary_admin_password, temporary_password);
   p2.setTypeName();
   strcpyT(p2.data, "test name aaa");
-  p2.length = strlen((const char *) p2.data);
   stick10_08::SendOTPData::CommandTransaction::run(stick, p2);
 
   p2 = get_payload<SendOTPData>();
   strcpyT(p2.temporary_admin_password, temporary_password);
   strcpyT(p2.data, RFC_SECRET);
-  p2.length = strlen(RFC_SECRET);
   p2.setTypeSecret();
   stick10_08::SendOTPData::CommandTransaction::run(stick, p2);
 
@@ -191,13 +187,11 @@ TEST_CASE("authorize user TOTP", "[pronew]") {
   strcpyT(p2.temporary_admin_password, temporary_password);
   p2.setTypeName();
   strcpyT(p2.data, "test name TOTP");
-  p2.length = strlen((const char *) p2.data);
   stick10_08::SendOTPData::CommandTransaction::run(stick, p2);
 
   p2 = get_payload<SendOTPData>();
   strcpyT(p2.temporary_admin_password, temporary_password);
   strcpyT(p2.data, RFC_SECRET);
-  p2.length = strlen(RFC_SECRET);
   p2.setTypeSecret();
   stick10_08::SendOTPData::CommandTransaction::run(stick, p2);
 

--- a/unittest/test3.cc
+++ b/unittest/test3.cc
@@ -49,18 +49,26 @@ TEST_CASE("write slot", "[pronew]"){
   connect_and_setup(stick);
   authorize(stick);
 
-  auto p = get_payload<WriteToHOTPSlot>();
-  strcpyT(p.slot_secret, RFC_SECRET);
+  auto p2 = get_payload<SendOTPData>();
+  strcpyT(p2.temporary_admin_password, temporary_password);
+  p2.setTypeName();
+  strcpyT(p2.data, "test name aaa");
+  p2.length = strlen((const char *) p2.data);
+  stick10_08::SendOTPData::CommandTransaction::run(stick, p2);
+
+  p2 = get_payload<SendOTPData>();
+  strcpyT(p2.temporary_admin_password, temporary_password);
+  strcpyT(p2.data, RFC_SECRET);
+  p2.length = strlen(RFC_SECRET);
+  p2.setTypeSecret();
+  stick10_08::SendOTPData::CommandTransaction::run(stick, p2);
+
+  auto p = get_payload<WriteToOTPSlot>();
   strcpyT(p.temporary_admin_password, temporary_password);
   p.use_8_digits = true;
-  stick10_08::WriteToHOTPSlot::CommandTransaction::run(stick, p);
-
-  auto p2 = get_payload<WriteToHOTPSlot_2>();
-  strcpyT(p2.temporary_admin_password, temporary_password);
-  p2.slot_number = 0 + 0x10;
-  p2.slot_counter = 0;
-  strcpyT(p2.slot_name, "test name aaa");
-  stick10_08::WriteToHOTPSlot_2::CommandTransaction::run(stick, p2);
+  p.slot_number = 0 + 0x10;
+  p.slot_counter_or_interval = 0;
+  stick10_08::WriteToOTPSlot::CommandTransaction::run(stick, p);
 
   auto pc = get_payload<WriteGeneralConfig>();
   pc.enable_user_password = 0;
@@ -119,23 +127,34 @@ TEST_CASE("authorize user HOTP", "[pronew]") {
   connect_and_setup(stick);
   authorize(stick);
 
-  auto p = get_payload<WriteGeneralConfig>();
-  p.enable_user_password = 1;
+  {
+    auto p = get_payload<WriteGeneralConfig>();
+    p.enable_user_password = 1;
+    strcpyT(p.temporary_admin_password, temporary_password);
+    WriteGeneralConfig::CommandTransaction::run(stick, p);
+  }
+
+  auto p2 = get_payload<SendOTPData>();
+  strcpyT(p2.temporary_admin_password, temporary_password);
+  p2.setTypeName();
+  strcpyT(p2.data, "test name aaa");
+  p2.length = strlen((const char *) p2.data);
+  stick10_08::SendOTPData::CommandTransaction::run(stick, p2);
+
+  p2 = get_payload<SendOTPData>();
+  strcpyT(p2.temporary_admin_password, temporary_password);
+  strcpyT(p2.data, RFC_SECRET);
+  p2.length = strlen(RFC_SECRET);
+  p2.setTypeSecret();
+  stick10_08::SendOTPData::CommandTransaction::run(stick, p2);
+
+  auto p = get_payload<WriteToOTPSlot>();
   strcpyT(p.temporary_admin_password, temporary_password);
-  WriteGeneralConfig::CommandTransaction::run(stick, p);
+  p.use_8_digits = true;
+  p.slot_number = 0 + 0x10;
+  p.slot_counter_or_interval = 0;
+  stick10_08::WriteToOTPSlot::CommandTransaction::run(stick, p);
 
-  auto pw = get_payload<WriteToHOTPSlot>();
-  strcpyT(pw.slot_secret, RFC_SECRET);
-  strcpyT(pw.temporary_admin_password, temporary_password);
-  pw.use_8_digits = true;
-  WriteToHOTPSlot::CommandTransaction::run(stick, pw);
-
-  auto pw2 = get_payload<WriteToHOTPSlot_2>();
-  strcpyT(pw2.temporary_admin_password, temporary_password);
-  pw2.slot_number = 0 + 0x10;
-  pw2.slot_counter = 0;
-  strcpyT(pw2.slot_name, "test name aaa");
-  WriteToHOTPSlot_2::CommandTransaction::run(stick, pw2);
 
   auto p3 = get_payload<GetHOTP>();
   p3.slot_number = 0 + 0x10;
@@ -161,23 +180,33 @@ TEST_CASE("authorize user TOTP", "[pronew]") {
   connect_and_setup(stick);
   authorize(stick);
 
-  auto p = get_payload<WriteGeneralConfig>();
-  p.enable_user_password = 1;
+  {
+    auto p = get_payload<WriteGeneralConfig>();
+    p.enable_user_password = 1;
+    strcpyT(p.temporary_admin_password, temporary_password);
+    WriteGeneralConfig::CommandTransaction::run(stick, p);
+  }
+
+  auto p2 = get_payload<SendOTPData>();
+  strcpyT(p2.temporary_admin_password, temporary_password);
+  p2.setTypeName();
+  strcpyT(p2.data, "test name TOTP");
+  p2.length = strlen((const char *) p2.data);
+  stick10_08::SendOTPData::CommandTransaction::run(stick, p2);
+
+  p2 = get_payload<SendOTPData>();
+  strcpyT(p2.temporary_admin_password, temporary_password);
+  strcpyT(p2.data, RFC_SECRET);
+  p2.length = strlen(RFC_SECRET);
+  p2.setTypeSecret();
+  stick10_08::SendOTPData::CommandTransaction::run(stick, p2);
+
+  auto p = get_payload<WriteToOTPSlot>();
   strcpyT(p.temporary_admin_password, temporary_password);
-  WriteGeneralConfig::CommandTransaction::run(stick, p);
-
-  auto pw = get_payload<WriteToTOTPSlot>();
-  strcpyT(pw.slot_secret, RFC_SECRET);
-  strcpyT(pw.temporary_admin_password, temporary_password);
-  pw.use_8_digits = true;
-  WriteToTOTPSlot::CommandTransaction::run(stick, pw);
-
-  auto pw2 = get_payload<WriteToTOTPSlot_2>();
-  strcpyT(pw2.temporary_admin_password, temporary_password);
-  pw2.slot_number = 0 + 0x20;
-  pw2.slot_interval= 30;
-  strcpyT(pw2.slot_name, "test name TOTP");
-  WriteToTOTPSlot_2::CommandTransaction::run(stick, pw2);
+  p.use_8_digits = true;
+  p.slot_number = 0 + 0x20;
+  p.slot_counter_or_interval = 30;
+  stick10_08::WriteToOTPSlot::CommandTransaction::run(stick, p);
 
   auto p_get_totp = get_payload<GetTOTP>();
   p_get_totp.slot_number = 0 + 0x20;

--- a/unittest/test_library.py
+++ b/unittest/test_library.py
@@ -1,6 +1,6 @@
 import pytest
 
-from misc import ffi, gs, to_hex
+from misc import ffi, gs, to_hex, is_pro_rtm_07, is_long_OTP_secret_handled
 from constants import DefaultPasswords, DeviceErrorCode, RFC_SECRET, LibraryErrors
 
 def test_too_long_strings(C):
@@ -50,6 +50,8 @@ def test_invalid_secret_hex_string_for_OTP_write(C, invalid_hex_string):
 
 def test_warning_binary_bigger_than_secret_buffer(C):
     invalid_hex_string = to_hex('1234567890') * 3
+    if is_long_OTP_secret_handled(C):
+        invalid_hex_string *= 2
     assert C.NK_write_hotp_slot(1, 'slot_name', invalid_hex_string, 0, True, False, False, '',
                                 DefaultPasswords.ADMIN_TEMP) == LibraryErrors.TARGET_BUFFER_SIZE_SMALLER_THAN_SOURCE
 

--- a/unittest/test_library.py
+++ b/unittest/test_library.py
@@ -3,6 +3,7 @@ import pytest
 from misc import ffi, gs, to_hex, is_pro_rtm_07, is_long_OTP_secret_handled
 from constants import DefaultPasswords, DeviceErrorCode, RFC_SECRET, LibraryErrors
 
+
 def test_too_long_strings(C):
     new_password = '123123123'
     long_string = 'a' * 100
@@ -35,6 +36,7 @@ def test_invalid_slot(C):
     assert gs(C.NK_get_password_safe_slot_login(invalid_slot)) == ''
     assert C.NK_get_last_command_status() == LibraryErrors.INVALID_SLOT
 
+
 @pytest.mark.parametrize("invalid_hex_string",
                          ['text', '00  ', '0xff', 'zzzzzzzzzzzz', 'fff', 'f' * 257, 'f' * 258])
 def test_invalid_secret_hex_string_for_OTP_write(C, invalid_hex_string):
@@ -47,7 +49,6 @@ def test_invalid_secret_hex_string_for_OTP_write(C, invalid_hex_string):
                                 DefaultPasswords.ADMIN_TEMP) == LibraryErrors.INVALID_HEX_STRING
     assert C.NK_write_totp_slot(1, 'python_test', invalid_hex_string, 30, True, False, False, "",
                                 DefaultPasswords.ADMIN_TEMP) == LibraryErrors.INVALID_HEX_STRING
-
 
 def test_warning_binary_bigger_than_secret_buffer(C):
     invalid_hex_string = to_hex('1234567890') * 3

--- a/unittest/test_library.py
+++ b/unittest/test_library.py
@@ -36,12 +36,13 @@ def test_invalid_slot(C):
     assert C.NK_get_last_command_status() == LibraryErrors.INVALID_SLOT
 
 @pytest.mark.parametrize("invalid_hex_string",
-                         ['text', '00  ', '0xff', 'zzzzzzzzzzzz', 'fff', '', 'f' * 257, 'f' * 258])
+                         ['text', '00  ', '0xff', 'zzzzzzzzzzzz', 'fff', 'f' * 257, 'f' * 258])
 def test_invalid_secret_hex_string_for_OTP_write(C, invalid_hex_string):
     """
     Tests for invalid secret hex string during writing to OTP slot. Invalid strings are not hexadecimal number,
     empty or longer than 255 characters.
     """
+    assert C.NK_first_authenticate(DefaultPasswords.ADMIN, DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
     assert C.NK_write_hotp_slot(1, 'slot_name', invalid_hex_string, 0, True, False, False, '',
                                 DefaultPasswords.ADMIN_TEMP) == LibraryErrors.INVALID_HEX_STRING
     assert C.NK_write_totp_slot(1, 'python_test', invalid_hex_string, 30, True, False, False, "",

--- a/unittest/test_library.py
+++ b/unittest/test_library.py
@@ -58,11 +58,6 @@ def test_warning_binary_bigger_than_secret_buffer(C):
                                 DefaultPasswords.ADMIN_TEMP) == LibraryErrors.TARGET_BUFFER_SIZE_SMALLER_THAN_SOURCE
 
 
-@pytest.mark.xfail(reason="TODO")
-def test_OTP_secret_started_from_null(C):
-    assert False
-
-
 @pytest.mark.skip(reason='Experimental')
 def test_clear(C):
     d = 'asdasdasd'

--- a/unittest/test_pro.py
+++ b/unittest/test_pro.py
@@ -2,7 +2,7 @@ import pytest
 
 from constants import DefaultPasswords, DeviceErrorCode, RFC_SECRET
 from misc import ffi, gs, wait, cast_pointer_to_tuple
-from misc import is_pro_rtm_07, is_storage
+from misc import is_pro_rtm_07, is_pro_rtm_08, is_storage
 
 def test_enable_password_safe(C):
     assert C.NK_lock_device() == DeviceErrorCode.STATUS_OK
@@ -61,7 +61,7 @@ def test_password_safe_slot_status(C):
 
 
 def test_issue_device_locks_on_second_key_generation_in_sequence(C):
-    if is_pro_rtm_07(C):
+    if is_pro_rtm_07(C) or is_pro_rtm_08(C):
         pytest.skip("issue to register: device locks up "
                      "after below commands sequence (reinsertion fixes), skipping for now")
     assert C.NK_build_aes_key(DefaultPasswords.ADMIN) == DeviceErrorCode.STATUS_OK

--- a/unittest/test_pro.py
+++ b/unittest/test_pro.py
@@ -74,6 +74,14 @@ def test_regenerate_aes_key(C):
     assert C.NK_build_aes_key(DefaultPasswords.ADMIN) == DeviceErrorCode.STATUS_OK
     assert C.NK_enable_password_safe(DefaultPasswords.USER) == DeviceErrorCode.STATUS_OK
 
+def test_enable_password_safe_after_factory_reset(C):
+    assert C.NK_lock_device() == DeviceErrorCode.STATUS_OK
+    assert C.NK_factory_reset(DefaultPasswords.ADMIN) == DeviceErrorCode.STATUS_OK
+    wait(10)
+    assert C.NK_enable_password_safe(DefaultPasswords.USER) == DeviceErrorCode.STATUS_AES_DEC_FAILED
+    assert C.NK_build_aes_key(DefaultPasswords.ADMIN) == DeviceErrorCode.STATUS_OK
+    assert C.NK_enable_password_safe(DefaultPasswords.USER) == DeviceErrorCode.STATUS_OK
+
 
 @pytest.mark.xfail(reason="NK Pro firmware bug: regenerating AES key command not always results in cleared slot data")
 def test_destroy_password_safe(C):
@@ -96,6 +104,7 @@ def test_destroy_password_safe(C):
 
     assert C.NK_first_authenticate(DefaultPasswords.ADMIN, DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
     assert C.NK_build_aes_key(DefaultPasswords.ADMIN) == DeviceErrorCode.STATUS_OK
+    assert C.NK_lock_device() == DeviceErrorCode.STATUS_OK
     assert C.NK_enable_password_safe(DefaultPasswords.USER) == DeviceErrorCode.STATUS_OK
 
     assert gs(C.NK_get_password_safe_slot_name(0)) != 'slotname1'

--- a/unittest/test_pro.py
+++ b/unittest/test_pro.py
@@ -630,3 +630,34 @@ def test_HOTP_secrets(C, secret):
     lib_res += (counter, lib_at(counter))
     assert dev_res == lib_res
 
+
+def test_edit_OTP_slot(C):
+    """
+    should change slots counter and name without changing its secret (using null secret for second update)
+    """
+    secret = RFC_SECRET
+    counter = 0
+    PIN_protection = False
+    use_8_digits = False
+    assert C.NK_first_authenticate(DefaultPasswords.ADMIN, DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
+    assert C.NK_write_config(255, 255, 255, PIN_protection, not PIN_protection,
+                             DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
+    slot_number = 0
+    assert C.NK_first_authenticate(DefaultPasswords.ADMIN, DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
+    first_name = 'edit slot'
+    assert C.NK_write_hotp_slot(slot_number, first_name, secret, counter, use_8_digits, False, False, "",
+                                DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
+    assert gs(C.NK_get_hotp_slot_name(slot_number)) == first_name
+
+
+    first_code = C.NK_get_hotp_code(slot_number)
+    changed_name = 'changedname'
+    empty_secret = ''
+    assert C.NK_first_authenticate(DefaultPasswords.ADMIN, DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
+    assert C.NK_write_hotp_slot(slot_number, changed_name, empty_secret, counter, use_8_digits, False, False, "",
+                                DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
+    second_code = C.NK_get_hotp_code(slot_number)
+    assert first_code == second_code
+    assert gs(C.NK_get_hotp_slot_name(slot_number)) == changed_name
+
+

--- a/unittest/test_pro.py
+++ b/unittest/test_pro.py
@@ -536,7 +536,7 @@ def test_HOTP_slots_read_write_counter(C, counter):
     lib_res = []
     for slot_number in range(3):
         assert C.NK_first_authenticate(DefaultPasswords.ADMIN, DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
-        assert C.NK_write_hotp_slot(slot_number, 'null_secret', secret, counter, use_8_digits, False, False, "",
+        assert C.NK_write_hotp_slot(slot_number, 'HOTP rw' + str(slot_number), secret, counter, use_8_digits, False, False, "",
                                     DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
         code_device = str(C.NK_get_hotp_code(slot_number))
         code_device = '0'+code_device if len(code_device) < 6 else code_device
@@ -546,7 +546,7 @@ def test_HOTP_slots_read_write_counter(C, counter):
 
 
 @pytest.mark.parametrize("period", [30,60] )
-@pytest.mark.parametrize("time", range(20,70,20) )
+@pytest.mark.parametrize("time", range(21,70,20) )
 def test_TOTP_slots_read_write_at_time_period(C, time, period):
     secret = RFC_SECRET
     oath = pytest.importorskip("oath")
@@ -561,7 +561,7 @@ def test_TOTP_slots_read_write_at_time_period(C, time, period):
     lib_res = []
     for slot_number in range(15):
         assert C.NK_first_authenticate(DefaultPasswords.ADMIN, DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
-        assert C.NK_write_totp_slot(slot_number, 'null_secret', secret, period, use_8_digits, False, False, "",
+        assert C.NK_write_totp_slot(slot_number, 'TOTP rw' + str(slot_number), secret, period, use_8_digits, False, False, "",
                                     DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
         assert C.NK_first_authenticate(DefaultPasswords.ADMIN, DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
         assert C.NK_totp_set_time(time) == DeviceErrorCode.STATUS_OK
@@ -569,6 +569,33 @@ def test_TOTP_slots_read_write_at_time_period(C, time, period):
         code_device = '0'+code_device if len(code_device) < 6 else code_device
         dev_res += (time, code_device)
         lib_res += (time, lib_at(time))
+    assert dev_res == lib_res
+
+
+@pytest.mark.parametrize("secret", [RFC_SECRET, 2*RFC_SECRET] )
+def test_TOTP_secrets(C, secret):
+    slot_number = 0
+    time = 0
+    period = 30
+    oath = pytest.importorskip("oath")
+    lib_at = lambda t: oath.totp(secret, t=t, period=period)
+    PIN_protection = False
+    use_8_digits = False
+    T = 0
+    assert C.NK_first_authenticate(DefaultPasswords.ADMIN, DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
+    assert C.NK_write_config(255, 255, 255, PIN_protection, not PIN_protection,
+                             DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
+    dev_res = []
+    lib_res = []
+    assert C.NK_first_authenticate(DefaultPasswords.ADMIN, DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
+    assert C.NK_write_totp_slot(slot_number, 'TOTP secret' + str(slot_number), secret, period, use_8_digits, False, False, "",
+                                DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
+    assert C.NK_first_authenticate(DefaultPasswords.ADMIN, DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
+    assert C.NK_totp_set_time(time) == DeviceErrorCode.STATUS_OK
+    code_device = str(C.NK_get_totp_code(slot_number, T, 0, period))
+    code_device = '0'+code_device if len(code_device) < 6 else code_device
+    dev_res += (time, code_device)
+    lib_res += (time, lib_at(time))
     assert dev_res == lib_res
 
 

--- a/unittest/test_pro.py
+++ b/unittest/test_pro.py
@@ -683,3 +683,23 @@ def test_edit_OTP_slot(C):
     assert gs(C.NK_get_hotp_slot_name(slot_number)) == changed_name
 
 
+@pytest.mark.skip
+@pytest.mark.parametrize("secret", ['31323334353637383930'*2,'31323334353637383930'*4] )
+def test_TOTP_codes_from_nitrokeyapp(secret, C):
+    """
+    Helper test for manual TOTP check of written secret by Nitrokey App
+    Destined to run by hand
+    """
+    slot_number = 0
+    PIN_protection = False
+    period = 30
+    assert C.NK_first_authenticate(DefaultPasswords.ADMIN, DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
+    assert C.NK_write_config(255, 255, 255, PIN_protection, not PIN_protection,
+                             DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
+    code_device = str(C.NK_get_totp_code(slot_number, 0, 0, period))
+    code_device = '0'+code_device if len(code_device) < 6 else code_device
+
+    oath = pytest.importorskip("oath")
+    lib_at = lambda : oath.totp(secret, period=period)
+    print (lib_at())
+    assert lib_at() == code_device

--- a/unittest/test_pro.py
+++ b/unittest/test_pro.py
@@ -695,6 +695,9 @@ def test_edit_OTP_slot(C):
     """
     should change slots counter and name without changing its secret (using null secret for second update)
     """
+    # counter does not reset under Storage v0.43
+    skip_if_device_version_lower_than({'S': 44, 'P': 7})
+
     secret = RFC_SECRET
     counter = 0
     PIN_protection = False

--- a/unittest/test_pro.py
+++ b/unittest/test_pro.py
@@ -81,7 +81,9 @@ def test_enable_password_safe_after_factory_reset(C):
     assert C.NK_lock_device() == DeviceErrorCode.STATUS_OK
     assert C.NK_factory_reset(DefaultPasswords.ADMIN) == DeviceErrorCode.STATUS_OK
     wait(10)
-    assert C.NK_enable_password_safe(DefaultPasswords.USER) == DeviceErrorCode.STATUS_AES_DEC_FAILED
+    enable_password_safe_result = C.NK_enable_password_safe(DefaultPasswords.USER)
+    assert enable_password_safe_result == DeviceErrorCode.STATUS_AES_DEC_FAILED \
+           or is_storage(C) and enable_password_safe_result == DeviceErrorCode.WRONG_PASSWORD
     assert C.NK_build_aes_key(DefaultPasswords.ADMIN) == DeviceErrorCode.STATUS_OK
     assert C.NK_enable_password_safe(DefaultPasswords.USER) == DeviceErrorCode.STATUS_OK
 

--- a/unittest/test_pro.py
+++ b/unittest/test_pro.py
@@ -635,13 +635,12 @@ def test_TOTP_secrets(C, secret):
 
 @pytest.mark.parametrize("secret", [RFC_SECRET, 2*RFC_SECRET, '12'*10, '12'*30] )
 def test_HOTP_secrets(C, secret):
-    '''
+    """
     NK Pro 0.8+, NK Storage 0.44+
-    '''
+    feature needed: support for 320bit secrets
+    """
     skip_if_device_version_lower_than({'S': 44, 'P': 8})
 
-    if is_pro_rtm_07(C) and len(secret)>20*2: #*2 since secret is in hex
-        pytest.skip("Secret lengths over 20 bytes are not supported by NK Pro 0.7 ")
     slot_number = 0
     counter = 0
     oath = pytest.importorskip("oath")

--- a/unittest/test_pro.py
+++ b/unittest/test_pro.py
@@ -509,12 +509,16 @@ def test_get_serial_number(C):
     print(('Serial number of the device: ', sn))
 
 
-@pytest.mark.parametrize("secret", ['000001', '00'*10+'ff', '00'*19+'ff', '000102', '002EF43F51AFA97BA2B46418768123C9E1809A5B' ])
+@pytest.mark.parametrize("secret", ['000001', '00'*10+'ff', '00'*19+'ff', '000102',
+                                    '00'*29+'ff', '00'*39+'ff', '002EF43F51AFA97BA2B46418768123C9E1809A5B' ])
 def test_OTP_secret_started_from_null(C, secret):
-    '''
+    """
     NK Pro 0.8+, NK Storage 0.43+
-    '''
+    """
     skip_if_device_version_lower_than({'S': 43, 'P': 8})
+    if len(secret) > 40:
+        # feature: 320 bit long secret handling
+        skip_if_device_version_lower_than({'S': 44, 'P': 8})
 
     oath = pytest.importorskip("oath")
     lib_at = lambda t: oath.hotp(secret, t, format='dec6')

--- a/unittest/test_pro.py
+++ b/unittest/test_pro.py
@@ -476,8 +476,6 @@ def test_read_write_config(C):
 
 
 def test_factory_reset(C):
-    if is_storage(C):
-        pytest.skip('Recovery not implemented for NK Storage')
     C.NK_set_debug(True)
     assert C.NK_first_authenticate(DefaultPasswords.ADMIN, DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
     assert C.NK_write_config(255, 255, 255, False, True, DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
@@ -494,6 +492,8 @@ def test_factory_reset(C):
     assert C.NK_build_aes_key(DefaultPasswords.ADMIN) == DeviceErrorCode.STATUS_OK
     assert C.NK_enable_password_safe(DefaultPasswords.USER) == DeviceErrorCode.STATUS_OK
     assert C.NK_lock_device() == DeviceErrorCode.STATUS_OK
+    if is_storage(C):
+        C.NK_clear_new_sd_card_warning(DefaultPasswords.ADMIN)
 
 
 def test_get_status(C):
@@ -573,6 +573,10 @@ def test_HOTP_slots_read_write_counter(C, counter):
 @pytest.mark.parametrize("period", [30,60] )
 @pytest.mark.parametrize("time", range(21,70,20) )
 def test_TOTP_slots_read_write_at_time_period(C, time, period):
+    """
+    Write to all TOTP slots with specified period, read code at specified time
+    and compare with 3rd party
+    """
     secret = RFC_SECRET
     oath = pytest.importorskip("oath")
     lib_at = lambda t: oath.totp(RFC_SECRET, t=t, period=period)

--- a/unittest/test_pro.py
+++ b/unittest/test_pro.py
@@ -84,6 +84,8 @@ def test_enable_password_safe_after_factory_reset(C):
     assert C.NK_lock_device() == DeviceErrorCode.STATUS_OK
     assert C.NK_factory_reset(DefaultPasswords.ADMIN) == DeviceErrorCode.STATUS_OK
     wait(10)
+    if is_storage(C):
+        assert C.NK_clear_new_sd_card_warning(DefaultPasswords.ADMIN) == DeviceErrorCode.STATUS_OK
     enable_password_safe_result = C.NK_enable_password_safe(DefaultPasswords.USER)
     assert enable_password_safe_result == DeviceErrorCode.STATUS_AES_DEC_FAILED \
            or is_storage(C) and enable_password_safe_result == DeviceErrorCode.WRONG_PASSWORD
@@ -496,7 +498,7 @@ def test_factory_reset(C):
     assert C.NK_enable_password_safe(DefaultPasswords.USER) == DeviceErrorCode.STATUS_OK
     assert C.NK_lock_device() == DeviceErrorCode.STATUS_OK
     if is_storage(C):
-        C.NK_clear_new_sd_card_warning(DefaultPasswords.ADMIN)
+       assert C.NK_clear_new_sd_card_warning(DefaultPasswords.ADMIN) == DeviceErrorCode.STATUS_OK
 
 
 def test_get_status(C):

--- a/unittest/test_pro.py
+++ b/unittest/test_pro.py
@@ -327,9 +327,12 @@ def test_TOTP_64bit_time(C):
     assert dev_res == lib_res
 
 
-@pytest.mark.xfail(reason="NK Pro: possible firmware bug or communication issue: set time command not always changes the time on stick thus failing this test, "
-                          "this does not influence normal use since setting time is not done every TOTP code request"
-                          "Rarely fail occurs on NK Storage")
+@pytest.mark.xfail(reason="NK Pro: Test fails in 50% of cases due to test vectors set 1 second before interval count change"
+                          "Here time is changed on seconds side only and miliseconds part is not being reset apparently"
+                          "This results in available time to test of half a second on average, thus 50% failed cases"
+                          "With disabled two first test vectors test passess 10/10 times"
+                          "Fail may also occurs on NK Storage with lower occurrency since it needs less time to execute "
+                          "commands")
 @pytest.mark.parametrize("PIN_protection", [False, True, ])
 def test_TOTP_RFC_usepin(C, PIN_protection):
     slot_number = 1
@@ -350,8 +353,8 @@ def test_TOTP_RFC_usepin(C, PIN_protection):
     # Mode: Sha1, time step X=30
     test_data = [
         #Time         T (hex)               TOTP
-        (59,          0x1,                94287082),
-        (1111111109,  0x00000000023523EC, 7081804),
+        (59,          0x1,                94287082), # Warning - test vector time 1 second before interval count changes
+        (1111111109,  0x00000000023523EC, 7081804), # Warning - test vector time 1 second before interval count changes
         (1111111111,  0x00000000023523ED, 14050471),
         (1234567890,  0x000000000273EF07, 89005924),
         (2000000000,  0x0000000003F940AA, 69279037),

--- a/unittest/test_pro.py
+++ b/unittest/test_pro.py
@@ -631,6 +631,25 @@ def test_HOTP_secrets(C, secret):
     assert dev_res == lib_res
 
 
+def test_special_double_press(C):
+    """
+    requires manual check after function run
+    double press each of num-, scroll-, caps-lock and check inserted OTP codes (each 1st should be 755224)
+    on nkpro 0.7 scrolllock should do nothing, on nkpro 0.8+ should return OTP code
+    """
+    secret = RFC_SECRET
+    counter = 0
+    PIN_protection = False
+    use_8_digits = False
+    assert C.NK_first_authenticate(DefaultPasswords.ADMIN, DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
+    assert C.NK_write_config(0, 1, 2, PIN_protection, not PIN_protection,
+                             DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
+    for slot_number in range(3):
+        assert C.NK_first_authenticate(DefaultPasswords.ADMIN, DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
+        assert C.NK_write_hotp_slot(slot_number, 'double' + str(slot_number), secret, counter, use_8_digits, False, False, "",
+                                DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
+    # requires manual check
+
 def test_edit_OTP_slot(C):
     """
     should change slots counter and name without changing its secret (using null secret for second update)

--- a/unittest/test_pro.py
+++ b/unittest/test_pro.py
@@ -7,6 +7,9 @@ from misc import is_pro_rtm_07, is_pro_rtm_08, is_storage
 
 
 def test_enable_password_safe(C):
+    """
+    All Password Safe tests depend on AES keys being initialized. They will fail otherwise.
+    """
     assert C.NK_lock_device() == DeviceErrorCode.STATUS_OK
     assert C.NK_enable_password_safe('wrong_password') == DeviceErrorCode.WRONG_PASSWORD
     assert C.NK_enable_password_safe(DefaultPasswords.USER) == DeviceErrorCode.STATUS_OK

--- a/unittest/test_pro.py
+++ b/unittest/test_pro.py
@@ -4,6 +4,7 @@ from constants import DefaultPasswords, DeviceErrorCode, RFC_SECRET
 from misc import ffi, gs, wait, cast_pointer_to_tuple
 from misc import is_pro_rtm_07, is_pro_rtm_08, is_storage
 
+
 def test_enable_password_safe(C):
     assert C.NK_lock_device() == DeviceErrorCode.STATUS_OK
     assert C.NK_enable_password_safe('wrong_password') == DeviceErrorCode.WRONG_PASSWORD
@@ -252,6 +253,7 @@ def test_HOTP_token(C):
         assert hotp_code != 0
         assert C.NK_get_last_command_status() == DeviceErrorCode.STATUS_OK
 
+
 def test_HOTP_counters(C):
     """
     # https://tools.ietf.org/html/rfc4226#page-32
@@ -373,6 +375,7 @@ def test_TOTP_RFC_usepin(C, PIN_protection):
         responses += [ (t, code_from_device) ]
         correct += expected_code == code_from_device
     assert data == responses or correct == len(test_data)
+
 
 def test_get_slot_names(C):
     C.NK_set_debug(True)
@@ -502,6 +505,7 @@ def test_get_serial_number(C):
     assert len(sn) > 0
     print(('Serial number of the device: ', sn))
 
+
 @pytest.mark.parametrize("secret", ['000001', '00'*10+'ff', '00'*19+'ff', '000102', '002EF43F51AFA97BA2B46418768123C9E1809A5B' ])
 def test_OTP_secret_started_from_null(C, secret):
     '''
@@ -577,6 +581,7 @@ def test_TOTP_slots_read_write_at_time_period(C, time, period):
         lib_res += (time, lib_at(time))
     assert dev_res == lib_res
 
+
 @pytest.mark.parametrize("secret", [RFC_SECRET, 2*RFC_SECRET, '12'*10, '12'*30] )
 def test_TOTP_secrets(C, secret):
     '''
@@ -605,6 +610,7 @@ def test_TOTP_secrets(C, secret):
     dev_res += (time, code_device)
     lib_res += (time, lib_at(time))
     assert dev_res == lib_res
+
 
 @pytest.mark.parametrize("secret", [RFC_SECRET, 2*RFC_SECRET, '12'*10, '12'*30] )
 def test_HOTP_secrets(C, secret):
@@ -652,6 +658,7 @@ def test_special_double_press(C):
         assert C.NK_write_hotp_slot(slot_number, 'double' + str(slot_number), secret, counter, use_8_digits, False, False, "",
                                 DefaultPasswords.ADMIN_TEMP) == DeviceErrorCode.STATUS_OK
     # requires manual check
+
 
 def test_edit_OTP_slot(C):
     """

--- a/unittest/test_storage.py
+++ b/unittest/test_storage.py
@@ -1,9 +1,10 @@
+import pprint
+
 import pytest
 
-from misc import ffi, gs, wait, cast_pointer_to_tuple
-from constants import DefaultPasswords, DeviceErrorCode, RFC_SECRET, LibraryErrors
-
-import pprint
+from conftest import skip_if_device_version_lower_than
+from constants import DefaultPasswords, DeviceErrorCode
+from misc import gs, wait
 pprint = pprint.PrettyPrinter(indent=4).pprint
 
 
@@ -22,6 +23,7 @@ def get_dict_from_dissect(status):
 
 
 def test_get_status_storage(C):
+    skip_if_device_version_lower_than({'S': 43})
     status_pointer = C.NK_get_status_storage_as_string()
     assert C.NK_get_last_command_status() == DeviceErrorCode.STATUS_OK
     status_string = gs(status_pointer)
@@ -32,6 +34,7 @@ def test_get_status_storage(C):
 
 
 def test_sd_card_usage(C):
+    skip_if_device_version_lower_than({'S': 43})
     data_pointer = C.NK_get_SD_usage_data_as_string()
     assert C.NK_get_last_command_status() == DeviceErrorCode.STATUS_OK
     data_string = gs(data_pointer)
@@ -41,11 +44,13 @@ def test_sd_card_usage(C):
 
 
 def test_encrypted_volume_unlock(C):
+    skip_if_device_version_lower_than({'S': 43})
     assert C.NK_lock_device() == DeviceErrorCode.STATUS_OK
     assert C.NK_unlock_encrypted_volume(DefaultPasswords.USER) == DeviceErrorCode.STATUS_OK
 
 
 def test_encrypted_volume_unlock_hidden(C):
+    skip_if_device_version_lower_than({'S': 43})
     hidden_volume_password = 'hiddenpassword'
     assert C.NK_lock_device() == DeviceErrorCode.STATUS_OK
     assert C.NK_unlock_encrypted_volume(DefaultPasswords.USER) == DeviceErrorCode.STATUS_OK
@@ -54,6 +59,7 @@ def test_encrypted_volume_unlock_hidden(C):
 
 @pytest.mark.skip(reason='hangs device, to report')
 def test_encrypted_volume_setup_multiple_hidden(C):
+    skip_if_device_version_lower_than({'S': 43})
     hidden_volume_password = 'hiddenpassword'
     p = lambda i: hidden_volume_password + str(i)
     assert C.NK_lock_device() == DeviceErrorCode.STATUS_OK
@@ -67,25 +73,30 @@ def test_encrypted_volume_setup_multiple_hidden(C):
 
 
 def test_unencrypted_volume_set_read_only(C):
+    skip_if_device_version_lower_than({'S': 43})
     assert C.NK_lock_device() == DeviceErrorCode.STATUS_OK
     assert C.NK_set_unencrypted_read_only(DefaultPasswords.USER) == DeviceErrorCode.STATUS_OK
 
 
 def test_unencrypted_volume_set_read_write(C):
+    skip_if_device_version_lower_than({'S': 43})
     assert C.NK_lock_device() == DeviceErrorCode.STATUS_OK
     assert C.NK_set_unencrypted_read_write(DefaultPasswords.USER) == DeviceErrorCode.STATUS_OK
 
 
 def test_export_firmware(C):
+    skip_if_device_version_lower_than({'S': 43})
     assert C.NK_export_firmware(DefaultPasswords.ADMIN) == DeviceErrorCode.STATUS_OK
 
 
 def test_clear_new_sd_card_notification(C):
+    skip_if_device_version_lower_than({'S': 43})
     assert C.NK_clear_new_sd_card_warning(DefaultPasswords.ADMIN) == DeviceErrorCode.STATUS_OK
 
 
 @pytest.mark.skip
 def test_fill_SD_card(C):
+    skip_if_device_version_lower_than({'S': 43})
     status = C.NK_fill_SD_card_with_random_data(DefaultPasswords.ADMIN)
     assert status == DeviceErrorCode.STATUS_OK or status == DeviceErrorCode.BUSY
     while 1:
@@ -97,12 +108,14 @@ def test_fill_SD_card(C):
 
 
 def test_get_busy_progress_on_idle(C):
+    skip_if_device_version_lower_than({'S': 43})
     value = C.NK_get_progress_bar_value()
     assert value == -1
     assert C.NK_get_last_command_status() == DeviceErrorCode.STATUS_OK
 
 
 def test_change_update_password(C):
+    skip_if_device_version_lower_than({'S': 43})
     wrong_password = 'aaaaaaaaaaa'
     assert C.NK_change_update_password(wrong_password, DefaultPasswords.UPDATE_TEMP) == DeviceErrorCode.WRONG_PASSWORD
     assert C.NK_change_update_password(DefaultPasswords.UPDATE, DefaultPasswords.UPDATE_TEMP) == DeviceErrorCode.STATUS_OK
@@ -110,5 +123,6 @@ def test_change_update_password(C):
 
 
 def test_send_startup(C):
+    skip_if_device_version_lower_than({'S': 43})
     time_seconds_from_epoch = 0 # FIXME set proper date
     assert C.NK_send_startup(time_seconds_from_epoch) == DeviceErrorCode.STATUS_OK


### PR DESCRIPTION
All devices pass the tests: Pro 0.7, 0.8, Storage 0.43
Tested under Ubuntu 16.10 with: Clang++ 3.8. Tested compilation also on G++ 6.2.

Support for Nitrokey Pro 0.8:
- new authorization mechanism
- longer OTP secrets

Additional tests:
- longer secrets
- start secret with null value
- write all OTP slots and check returned code (confirm with oath library)

Ability to skip the test if the device does not support it.
Assumed features for Pro 0.8 will be available in Storage 0.44