### PR TITLE
Add a getter for the library version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,29 @@ project(libnitrokey)
 SET(PROJECT_VERSION "3.0-alpha")
 set(CMAKE_CXX_STANDARD 14)
 
+# Getter for the library version
+#
+# If a git tag is available, we use it.
+# Else, we use a git version and we raise a warning.
+#
+exec_program(
+  "git"
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ARGS "describe"
+  OUTPUT_VARIABLE GIT_VERSION)
+
+IF(${GIT_TAG} MATCHES "fatal:.*")
+MESSAGE(WARNING "Unable to find a git tag. Using git version instead.")
+exec_program(
+  "git"
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ARGS "rev-parse HEAD"
+  OUTPUT_VARIABLE GIT_VERSION)
+ENDIF()
+
+MESSAGE("LIBRARY VERSION: ${GIT_VERSION} ")
+ADD_DEFINITIONS(-DVERSION="${GIT_VERSION}")
+
 OPTION(LIBNITROKEY_STATIC "Build libnitrokey statically" TRUE)
 
 

--- a/NK_C_API.cc
+++ b/NK_C_API.cc
@@ -169,6 +169,10 @@ void clear_string(std::string &s){
     std::fill(s.begin(), s.end(), ' ');
 }
 
+NK_C_API const char * NK_version() {
+   return VERSION;
+}
+
 NK_C_API const char * NK_status() {
     auto m = NitrokeyManager::instance();
     return get_with_string_result([&](){

--- a/NK_C_API.h
+++ b/NK_C_API.h
@@ -36,6 +36,14 @@ NK_C_API int NK_login_auto();
 NK_C_API int NK_logout();
 
 /**
+ * Return the version of the library.
+ * If a git tag is available, return it else return the git version.
+ * This value is defined at the compilation time.
+ * @return the version of the library
+ */
+NK_C_API const char * NK_version();
+
+/**
  * Return the debug status string. Debug purposes.
  * @return command processing error code
  */


### PR DESCRIPTION
The git version is save when running CMake.
This value is accessible in the code with "VERSION".

Address the issue #35 .

Signed-off-by: Elie Tournier <tournier.elie@gmail.com>