### PR TITLE
test3.cc: fix syntax error

### DIFF
--- a/unittest/test3.cc
+++ b/unittest/test3.cc
@@ -113,7 +113,7 @@ TEST_CASE("write general config", "[pronew]") {
   auto p = get_payload<WriteGeneralConfig>();
   p.enable_user_password = 1;
   REQUIRE_THROWS(
-      WriteGeneralConfig::CommandTransaction::run(stick, p);
+      WriteGeneralConfig::CommandTransaction::run(stick, p)
   );
   strcpyT(p.temporary_admin_password, temporary_password);
   WriteGeneralConfig::CommandTransaction::run(stick, p);
@@ -154,7 +154,7 @@ TEST_CASE("authorize user HOTP", "[pronew]") {
   auto p3 = get_payload<GetHOTP>();
   p3.slot_number = 0 + 0x10;
   REQUIRE_THROWS(
-      GetHOTP::CommandTransaction::run(stick, p3);
+      GetHOTP::CommandTransaction::run(stick, p3)
   );
   strcpyT(p3.temporary_user_password, temporary_password);
   auto code_response = GetHOTP::CommandTransaction::run(stick, p3);
@@ -205,7 +205,7 @@ TEST_CASE("authorize user TOTP", "[pronew]") {
   p_get_totp.slot_number = 0 + 0x20;
 
   REQUIRE_THROWS(
-      GetTOTP::CommandTransaction::run(stick, p_get_totp);
+      GetTOTP::CommandTransaction::run(stick, p_get_totp)
   );
   strcpyT(p_get_totp.temporary_user_password, temporary_password);
 


### PR DESCRIPTION
```cxx
In file included from /usr/include/catch/catch.hpp:34:0,
                 from /home/brain/rpmbuild/BUILD/libnitrokey-7f7cfeb45b579204e0bc94bea37e2c810d2e5ec9/unittest/test3.cc:7:
/home/brain/rpmbuild/BUILD/libnitrokey-7f7cfeb45b579204e0bc94bea37e2c810d2e5ec9/unittest/test3.cc: In function 'void ____C_A_T_C_H____T_E_S_T____4()':
/home/brain/rpmbuild/BUILD/libnitrokey-7f7cfeb45b579204e0bc94bea37e2c810d2e5ec9/unittest/test3.cc:116:60: error: expected ')' before ';' token
       WriteGeneralConfig::CommandTransaction::run(stick, p);
                                                            ^
/home/brain/rpmbuild/BUILD/libnitrokey-7f7cfeb45b579204e0bc94bea37e2c810d2e5ec9/unittest/test3.cc:115:3: error: expected primary-expression before ')' token
   REQUIRE_THROWS(
   ^
/home/brain/rpmbuild/BUILD/libnitrokey-7f7cfeb45b579204e0bc94bea37e2c810d2e5ec9/unittest/test3.cc: In function 'void ____C_A_T_C_H____T_E_S_T____6()':
/home/brain/rpmbuild/BUILD/libnitrokey-7f7cfeb45b579204e0bc94bea37e2c810d2e5ec9/unittest/test3.cc:157:50: error: expected ')' before ';' token
       GetHOTP::CommandTransaction::run(stick, p3);
                                                  ^
/home/brain/rpmbuild/BUILD/libnitrokey-7f7cfeb45b579204e0bc94bea37e2c810d2e5ec9/unittest/test3.cc:156:3: error: expected primary-expression before ')' token
   REQUIRE_THROWS(
   ^
/home/brain/rpmbuild/BUILD/libnitrokey-7f7cfeb45b579204e0bc94bea37e2c810d2e5ec9/unittest/test3.cc: In function 'void ____C_A_T_C_H____T_E_S_T____10()':
/home/brain/rpmbuild/BUILD/libnitrokey-7f7cfeb45b579204e0bc94bea37e2c810d2e5ec9/unittest/test3.cc:208:58: error: expected ')' before ';' token
       GetTOTP::CommandTransaction::run(stick, p_get_totp);
                                                          ^
/home/brain/rpmbuild/BUILD/libnitrokey-7f7cfeb45b579204e0bc94bea37e2c810d2e5ec9/unittest/test3.cc:207:3: error: expected primary-expression before ')' token
   REQUIRE_THROWS(
   ^
```

Signed-off-by: Igor Gnatenko <ignatenkobrain@fedoraproject.org>