### PR TITLE
Build system fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 os: osx
 env:
   global:
-    - CF=-DCOMPILE_OFFLINE_TESTS=1
+    - CF="-DCOMPILE_OFFLINE_TESTS=1 -DERROR_ON_WARNING=ON"
 
 matrix:
   include:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,45 +1,34 @@
 # https://cmake.org/pipermail/cmake/2011-May/044166.html
-    IF(NOT DEFINED CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_NO_WARNINGS)
-      SET(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_NO_WARNINGS ON)
-    ENDIF()
+IF(NOT DEFINED CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_NO_WARNINGS)
+    SET(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_NO_WARNINGS ON)
+ENDIF()
 
 cmake_minimum_required(VERSION 3.1)
 IF (UNIX)
-    OPTION(USE_CLANG "Use CLang" FALSE)
-    IF(USE_CLANG)
-        set(CMAKE_CXX_COMPILER "/usr/bin/clang++" CACHE string "clang++ compiler" FORCE)
-    ELSE()
-        set(CMAKE_CXX_COMPILER)
-    ENDIF()
     OPTION(ADD_ASAN "Use ASAN to show memory issues" FALSE)
     OPTION(ADD_TSAN "Use TSAN to show thread issues" FALSE)
     IF(ADD_ASAN)
         SET(EXTRA_LIBS ${EXTRA_LIBS} asan )
-        ADD_DEFINITIONS(-fsanitize=address -fno-omit-frame-pointer)
+        ADD_COMPILE_OPTIONS(-fsanitize=address -fno-omit-frame-pointer)
     ENDIF()
     IF(ADD_TSAN)
         SET(EXTRA_LIBS ${EXTRA_LIBS} tsan )
         SET(USE_CLANG TRUE)
-        ADD_DEFINITIONS(-fsanitize=thread -fno-omit-frame-pointer -fPIC -g) #use with clang
+        ADD_COMPILE_OPTIONS(-fsanitize=thread -fno-omit-frame-pointer -fPIC -g) #use with clang
     ENDIF()
     IF(ADD_TSAN AND ADD_ASAN)
         message(FATAL_ERROR "TSAN and ASAN cannot be used at the same time")
     ENDIF()
 ENDIF()
 
-project(libnitrokey)
-SET(PROJECT_VERSION "3.1")
+project(libnitrokey LANGUAGES C CXX VERSION 3.1.0)
 set(CMAKE_CXX_STANDARD 14)
-
-set(LIBNK_VERSION_MAJOR 3) #  reminder: incompatible API changes
-set(LIBNK_VERSION_MINOR 1) #  add functionality in a backwards-compatible manner
-set(LIBNK_VERSION_PATCH 0) #  make backwards-compatible bug fixes
-set(LIBNK_VERSION ${LIBNK_VERSION_MAJOR}.${LIBNK_VERSION_MINOR}.${LIBNK_VERSION_PATCH} )
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 
 include(GNUInstallDirs)
 
-OPTION(LIBNITROKEY_STATIC "Build libnitrokey statically" FALSE)
 
 
 IF (NOT CMAKE_BUILD_TYPE)
@@ -80,34 +69,32 @@ set(SOURCE_FILES
     NK_C_API.cc
         DeviceCommunicationExceptions.cpp)
 
+set(BUILD_SHARED_LIBS ON CACHE BOOL "Build all libraries as shared")
+add_library(nitrokey ${SOURCE_FILES})
+
 IF(APPLE)
-	include_directories(hidapi/hidapi)
-	add_library(hidapi-libusb STATIC hidapi/mac/hid.c )
-	target_link_libraries(hidapi-libusb "-framework CoreFoundation" "-framework IOKit")
+    include_directories(hidapi/hidapi)
+    add_library(hidapi-libusb STATIC hidapi/mac/hid.c )
+    target_link_libraries(hidapi-libusb "-framework CoreFoundation" "-framework IOKit")
+    target_link_libraries(nitrokey hidapi-libusb)
 ELSEIF(UNIX)
-#	add_library(hidapi-libusb STATIC hidapi/libusb/hid.c )
+#    add_library(hidapi-libusb STATIC hidapi/libusb/hid.c )
+    find_package(PkgConfig)
+    pkg_search_module(HIDAPI_LIBUSB REQUIRED hidapi-libusb)
+    target_compile_options(nitrokey PRIVATE ${HIDAPI_LIBUSB_CFLAGS})
+    target_link_libraries(nitrokey ${HIDAPI_LIBUSB_LDFLAGS})
 ELSEIF(WIN32)
-	include_directories(hidapi/hidapi)
-	add_library(hidapi-libusb STATIC hidapi/windows/hid.c )
-	target_link_libraries(hidapi-libusb setupapi)
+    include_directories(hidapi/hidapi)
+    add_library(hidapi-libusb STATIC hidapi/windows/hid.c )
+    target_link_libraries(hidapi-libusb setupapi)
+    target_link_libraries(nitrokey hidapi-libusb)
 ENDIF()
 
+set_target_properties(nitrokey PROPERTIES
+	VERSION ${libnitrokey_VERSION}
+	SOVERSION ${libnitrokey_VERSION_MAJOR})
 
-IF (NOT LIBNITROKEY_STATIC)
-    add_library(nitrokey SHARED ${SOURCE_FILES})
-    SET(LIBNAME nitrokey)
-ELSE()
-    add_library(nitrokey-static STATIC ${SOURCE_FILES})    
-	SET(LIBNAME nitrokey-static)
-ENDIF()
-
-
-target_link_libraries(${LIBNAME} hidapi-libusb)
-
-set_target_properties(${LIBNAME} PROPERTIES VERSION ${LIBNK_VERSION}
-        SOVERSION ${LIBNK_VERSION_MAJOR} )
-
-OPTION(ERROR_ON_WARNING "Stop compilation on warning found (not supported for MSVC)" ON)
+OPTION(ERROR_ON_WARNING "Stop compilation on warning found (not supported for MSVC)" OFF)
 if (NOT MSVC)
     set(COMPILE_FLAGS "-Wall -Wno-unused-function -Wcast-qual -Woverloaded-virtual")
     IF(NOT APPLE)
@@ -115,35 +102,35 @@ if (NOT MSVC)
             set(COMPILE_FLAGS "${COMPILE_FLAGS} -Werror")
         endif()
     ENDIF()
-    SET_TARGET_PROPERTIES(${LIBNAME} PROPERTIES COMPILE_FLAGS ${COMPILE_FLAGS} )
+    SET_TARGET_PROPERTIES(nitrokey PROPERTIES COMPILE_FLAGS ${COMPILE_FLAGS} )
 endif()
 
 OPTION(NO_LOG "Compile without logging functionality and its strings (decreases size)" OFF)
 IF (NO_LOG)
-    SET_TARGET_PROPERTIES(${LIBNAME} PROPERTIES COMPILE_DEFINITIONS "NO_LOG")
+    SET_TARGET_PROPERTIES(nitrokey PROPERTIES COMPILE_DEFINITIONS "NO_LOG")
 ENDIF()
 
 OPTION(LOG_VOLATILE_DATA "Log volatile data (debug)" OFF)
 IF (LOG_VOLATILE_DATA)
-    SET_TARGET_PROPERTIES(${LIBNAME} PROPERTIES COMPILE_DEFINITIONS "LOG_VOLATILE_DATA")
+    SET_TARGET_PROPERTIES(nitrokey PROPERTIES COMPILE_DEFINITIONS "LOG_VOLATILE_DATA")
 ENDIF()
 
 
 file(GLOB LIB_INCLUDES "include/*.h")
-install (FILES ${LIB_INCLUDES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libnitrokey)
-install (TARGETS ${LIBNAME} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install (FILES ${LIB_INCLUDES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
+install (TARGETS nitrokey DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 OPTION(COMPILE_TESTS "Compile tests" FALSE)
 OPTION(COMPILE_OFFLINE_TESTS "Compile offline tests" FALSE)
 
 IF(COMPILE_OFFLINE_TESTS OR COMPILE_TESTS)
     include_directories(unittest/Catch/include)
-    add_library(catch SHARED unittest/catch_main.cpp )
+    add_library(catch STATIC unittest/catch_main.cpp )
 ENDIF()
 
 IF(COMPILE_OFFLINE_TESTS)
     add_executable (test_offline unittest/test_offline.cc)
-    target_link_libraries (test_offline ${EXTRA_LIBS} ${LIBNAME} catch)
+    target_link_libraries (test_offline ${EXTRA_LIBS} nitrokey catch)
     #run with 'make test' or 'ctest'
     include (CTest)
     add_test (runs test_offline)
@@ -153,22 +140,22 @@ IF (COMPILE_TESTS)
     #needs connected PRO device for success
     #warning: it may delete data on the device
     add_executable (test_C_API unittest/test_C_API.cpp)
-    target_link_libraries (test_C_API ${EXTRA_LIBS} ${LIBNAME} catch)
+    target_link_libraries (test_C_API ${EXTRA_LIBS} nitrokey catch)
 
     add_executable (test2 unittest/test2.cc)
-    target_link_libraries (test2 ${EXTRA_LIBS} ${LIBNAME} catch)
+    target_link_libraries (test2 ${EXTRA_LIBS} nitrokey catch)
 
     add_executable (test3 unittest/test3.cc)
-    target_link_libraries (test3 ${EXTRA_LIBS} ${LIBNAME} catch)
+    target_link_libraries (test3 ${EXTRA_LIBS} nitrokey catch)
 
     add_executable (test_HOTP unittest/test_HOTP.cc)
-    target_link_libraries (test_HOTP ${EXTRA_LIBS} ${LIBNAME} catch)
+    target_link_libraries (test_HOTP ${EXTRA_LIBS} nitrokey catch)
 
     add_executable (test1 unittest/test.cc)
-    target_link_libraries (test1 ${EXTRA_LIBS} ${LIBNAME} catch)
+    target_link_libraries (test1 ${EXTRA_LIBS} nitrokey catch)
 
     add_executable (test_issues unittest/test_issues.cc)
-    target_link_libraries (test_issues ${EXTRA_LIBS} ${LIBNAME} catch)
+    target_link_libraries (test_issues ${EXTRA_LIBS} nitrokey catch)
 
 ENDIF()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,10 @@ file(GLOB LIB_INCLUDES "include/*.h")
 install (FILES ${LIB_INCLUDES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
 install (TARGETS nitrokey DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
+# configure and install pkg-config file
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libnitrokey.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libnitrokey-1.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libnitrokey-1.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
 OPTION(COMPILE_TESTS "Compile tests" FALSE)
 OPTION(COMPILE_OFFLINE_TESTS "Compile offline tests" FALSE)
 

--- a/libnitrokey.pc.in
+++ b/libnitrokey.pc.in
@@ -1,0 +1,10 @@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: libnitrokey
+Description: Library for communicating with Nitrokey in a clean and easy manner
+Version: @libnitrokey_VERSION@
+Requires.private: hidapi-libusb
+
+Libs: -L${libdir} -lnitrokey
+Cflags: -I${includedir}


### PR DESCRIPTION
Modernise CMake

* Make indentation uniform
* Find libhid via pkg-config on Unix
* Use `BUILD_SHARED_LIBS`, which is the idiomatic way to switch between static and shared libraries in CMake.
    https://cmake.org/cmake/help/v3.0/variable/BUILD_SHARED_LIBS.html
* Remove Clang option. To use Clang, pass `CXX=clang++` as an environmental parameter to the CMake call.
* Do not enable `-Werror` by default. This just causes unnecessary issues with new compiler releases.
    https://blog.flameeyes.eu/2009/02/future-proof-your-code-dont-use-werror/