### PR TITLE
Add udev rules (moved from Nitrokey App)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,25 @@ file(GLOB LIB_INCLUDES "include/*.h" "NK_C_API.h")
 install (FILES ${LIB_INCLUDES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
 install (TARGETS nitrokey DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
+IF(NOT WIN32)
+    # Install Nitrokey udev rules
+    set(PKG_GET_UDEV_DIR ${PKG_CONFIG_EXECUTABLE} --variable=udevdir udev)
+    execute_process(COMMAND ${PKG_GET_UDEV_DIR} RESULT_VARIABLE ERR OUTPUT_VARIABLE UDEV_MAIN_DIR OUTPUT_STRIP_TRAILING_WHITESPACE)
+    IF(${ERR})
+        set(UDEV_MAIN_DIR "lib/udev/rules.d")
+    ELSE()
+        set(UDEV_MAIN_DIR "${UDEV_MAIN_DIR}/rules.d")
+    ENDIF()
+    string(REGEX REPLACE "^/" "" UDEV_MAIN_DIR "${UDEV_MAIN_DIR}")
+    string(REGEX REPLACE "^usr/" "" UDEV_MAIN_DIR "${UDEV_MAIN_DIR}") # usual prefix is usr/local
+    message(STATUS "Setting udev rules dir to ${UDEV_MAIN_DIR}")
+
+    install(FILES
+            ${CMAKE_SOURCE_DIR}/data/41-nitrokey.rules
+            DESTINATION ${UDEV_MAIN_DIR}
+    )
+ENDIF()
+
 # configure and install pkg-config file
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libnitrokey.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libnitrokey-1.pc @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libnitrokey-1.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/data/41-nitrokey.rules
+++ b/data/41-nitrokey.rules
@@ -1,0 +1,23 @@
+# Nitrokey U2F
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", MODE="0664", GROUP="plugdev", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="f1d0"
+
+SUBSYSTEM!="usb", GOTO="gnupg_rules_end"
+ACTION!="add", GOTO="gnupg_rules_end"
+
+# USB SmartCard Readers
+## Crypto Stick 1.2
+ATTR{idVendor}=="20a0", ATTR{idProduct}=="4107", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", GROUP+="plugdev", TAG+="uaccess"
+## Nitrokey Pro
+ATTR{idVendor}=="20a0", ATTR{idProduct}=="4108", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", GROUP+="plugdev", TAG+="uaccess"
+## Nitrokey Storage
+ATTR{idVendor}=="20a0", ATTR{idProduct}=="4109", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", GROUP+="plugdev", TAG+="uaccess"
+## Nitrokey Start
+ATTR{idVendor}=="20a0", ATTR{idProduct}=="4211", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", GROUP+="plugdev", TAG+="uaccess"
+## Nitrokey HSM
+ATTR{idVendor}=="20a0", ATTR{idProduct}=="4230", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", GROUP+="plugdev", TAG+="uaccess"
+
+LABEL="gnupg_rules_end"
+
+
+# Nitrokey Storage dev Entry
+KERNEL=="sd?1", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4109", SYMLINK+="nitrospace"

--- a/libnitrokey.pro
+++ b/libnitrokey.pro
@@ -3,6 +3,7 @@
 
 CONFIG   += c++14 shared debug
 
+
 TEMPLATE     = lib
 TARGET = nitrokey
 
@@ -31,6 +32,7 @@ HEADERS = \
    $$PWD/include/stick10_commands_0.8.h \
    $$PWD/include/stick20_commands.h \
    $$PWD/NK_C_API.h
+
 
 SOURCES = \
    $$PWD/command_id.cc \
@@ -77,3 +79,12 @@ INCLUDEPATH = \
 
 #DEFINES = 
 
+unix:!macx{
+        # Install rules for QMake (CMake is preffered though)
+        headers.files = $$HEADERS
+        headers.path = /usr/local/include/libnitrokey/
+        INSTALLS += headers
+
+        libbin.path = /usr/local/lib
+        INSTALLS += libbin
+}

--- a/libnitrokey.pro
+++ b/libnitrokey.pro
@@ -81,6 +81,16 @@ INCLUDEPATH = \
 
 unix:!macx{
         # Install rules for QMake (CMake is preffered though)
+        udevrules.path = $$system(pkg-config --variable=udevdir udev)
+        isEmpty(udevrules.path){
+            udevrules.path = "/lib/udev/"
+            message("Could not detect path for udev rules - setting default: " $$udevrules.path)
+        }
+        udevrules.path = $$udevrules.path"/rules.d"
+        udevrules.files = $$PWD/"data/41-nitrokey.rules"
+        message ($$udevrules.files)
+        INSTALLS +=udevrules
+
         headers.files = $$HEADERS
         headers.path = /usr/local/include/libnitrokey/
         INSTALLS += headers


### PR DESCRIPTION
Add udev rules (moved from Nitrokey App)
Add installation rules for Qt's QMake (CMake is still preferred though).