### PR TITLE
Expose firmware update in C API

### DIFF
--- a/NK_C_API.cc
+++ b/NK_C_API.cc
@@ -538,6 +538,13 @@ extern "C" {
 		});
 	}
 
+	NK_C_API int NK_enable_firmware_update(const char* update_password){
+		auto m = NitrokeyManager::instance();
+		return get_without_result([&]() {
+			m->enable_firmware_update(update_password);
+		});
+	}
+
 	NK_C_API const char* NK_get_status_storage_as_string() {
 		auto m = NitrokeyManager::instance();
 		return get_with_string_result([&]() {

--- a/NK_C_API.h
+++ b/NK_C_API.h
@@ -479,8 +479,9 @@ extern "C" {
 	 * When device is in update mode it no longer accepts any HID commands until
 	 * firmware is launched (regardless of being updated or not).
 	 * Smartcard (through CCID interface) and its all volumes are not visible as well.
-	 * Its VID and PID are changed to factory-default to be detected by flashing software.
-	 * Result of this command can be reversed by using 'launch' command.
+	 * Its VID and PID are changed to factory-default (03eb:2ff1 Atmel Corp.)
+	 * to be detected by flashing software. Result of this command can be reversed
+	 * by using 'launch' command.
 	 * For dfu-programmer it would be: 'dfu-programmer at32uc3a3256s launch'.
 	 * Storage only
 	 * @param update_password 20 characters

--- a/NK_C_API.h
+++ b/NK_C_API.h
@@ -475,6 +475,20 @@ extern "C" {
 		const char* new_update_password);
 
 	/**
+	 * Enter update mode. Needs update password.
+	 * When device is in update mode it no longer accepts any HID commands until
+	 * firmware is launched (regardless of being updated or not).
+	 * Smartcard (through CCID interface) and its all volumes are not visible as well.
+	 * Its VID and PID are changed to factory-default to be detected by flashing software.
+	 * Result of this command can be reversed by using 'launch' command.
+	 * For dfu-programmer it would be: 'dfu-programmer at32uc3a3256s launch'.
+	 * Storage only
+	 * @param update_password 20 characters
+	 * @return command processing error code
+	 */
+	NK_C_API int NK_enable_firmware_update(const char* update_password);
+
+	/**
 	 * Get Storage stick status as string.
 	 * Storage only
 	 * @return string with devices attributes

--- a/unittest/test_storage.py
+++ b/unittest/test_storage.py
@@ -318,6 +318,15 @@ def test_change_update_password(C):
     assert C.NK_change_update_password(DefaultPasswords.UPDATE_TEMP, DefaultPasswords.UPDATE) == DeviceErrorCode.STATUS_OK
 
 
+@pytest.mark.skip(reason='no reversing method added yet')
+@pytest.mark.update
+def test_enable_firmware_update(C):
+    skip_if_device_version_lower_than({'S': 50})
+    wrong_password = b'aaaaaaaaaaa'
+    assert C.NK_enable_firmware_update(wrong_password) == DeviceErrorCode.WRONG_PASSWORD
+    assert C.NK_enable_firmware_update(DefaultPasswords.UPDATE) == DeviceErrorCode.STATUS_OK
+
+
 @pytest.mark.other
 def test_send_startup(C):
     skip_if_device_version_lower_than({'S': 43})


### PR DESCRIPTION
Expose enabling firmware update mode for Storage in C API.
Until now it was available only in C++ API.
Add Python test for it as well - works on Ubuntu 18.04 with Storage v0.50.