### PR TITLE
Include stdbool.h in NK_C_API.h

### DIFF
--- a/NK_C_API.h
+++ b/NK_C_API.h
@@ -22,6 +22,7 @@
 #ifndef LIBNITROKEY_NK_C_API_H
 #define LIBNITROKEY_NK_C_API_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #ifdef _MSC_VER


### PR DESCRIPTION
`NK_C_API.h` uses the type bool although it is not defined in standard C. Since C99, the header `stdbool.h` provides this type, so this patch includes it in `NK_C_API.h` to make it valid C code.  (Note that the API already required C99 for the `//`-style comments.)