### PR TITLE
Null-terminate string before calling strtoul

### DIFF
--- a/misc.cc
+++ b/misc.cc
@@ -43,7 +43,8 @@ namespace misc {
     auto data = ::std::vector<uint8_t>();
     data.reserve(d_size);
 
-    char buf[2];
+    char buf[3];
+    buf[2] = '\0';
     for(size_t i=0; i<s_size; i++){
 
         char c = hexString[i];


### PR DESCRIPTION
hex_string_to_byte in misc.cc calls strtoul with a non-null-terminated
string, causing a buffer over-read.  This patch extends the buffer to
always include a null character in the end.

Fixes issue #95.