### PR TITLE
Null-terminate the argument for strtoul

### DIFF
--- a/unittest/test_HOTP.cc
+++ b/unittest/test_HOTP.cc
@@ -36,7 +36,8 @@ using namespace nitrokey::misc;
 
 void hexStringToByte(uint8_t data[], const char* hexString){
   REQUIRE(strlen(hexString)%2==0);
-    char buf[2];
+    char buf[3];
+    buf[2] = '\0';
     for(int i=0; i<strlen(hexString); i++){
         buf[i%2] = hexString[i];
         if (i%2==1){


### PR DESCRIPTION
As discussed in issue #95, the buffer passed to strtoul must be null-terminated.  This patch null-terminates the buffer used in `hexStringToByte` in the `test_HOTP` unit test to avoid a buffer over-read.