### PR TITLE
Add connect functions accepting an enum value

### DIFF
--- a/NK_C_API.cc
+++ b/NK_C_API.cc
@@ -161,6 +161,22 @@ extern "C" {
 		return 0;
 	}
 
+        NK_C_API int NK_login_enum(NK_device_model device_model) {
+                const char *model_string;
+                switch (device_model) {
+                    case NK_PRO:
+                        model_string = "P";
+                        break;
+                    case NK_STORAGE:
+                        model_string = "S";
+                        break;
+                    default:
+                        /* no such enum value -- return error code */
+                        return 0;
+                }
+                return NK_login(model_string);
+        }
+
 	NK_C_API int NK_logout() {
 		auto m = NitrokeyManager::instance();
 		return get_without_result([&]() {

--- a/NK_C_API.h
+++ b/NK_C_API.h
@@ -34,6 +34,21 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+        /**
+         * The Nitrokey device models supported by the API.
+         */
+        enum NK_device_model {
+            /**
+             * Nitrokey Pro.
+             */
+            NK_PRO,
+            /**
+             * Nitrokey Storage.
+             */
+            NK_STORAGE
+        };
+
 	/**
 	 * Set debug level of messages written on stderr
 	 * @param state state=True - most messages, state=False - only errors level
@@ -52,6 +67,13 @@ extern "C" {
 	 * @return 1 if connected, 0 if wrong model or cannot connect
 	 */
 	NK_C_API int NK_login(const char *device_model);
+
+	/**
+	 * Connect to device of given model. Currently library can be connected only to one device at once.
+	 * @param device_model NK_device_model: NK_PRO: Nitrokey Pro, NK_STORAGE: Nitrokey Storage
+	 * @return 1 if connected, 0 if wrong model or cannot connect
+	 */
+        NK_C_API int NK_login_enum(NK_device_model device_model);
 
 	/**
 	 * Connect to first available device, starting checking from Pro 1st to Storage 2nd.

--- a/NitrokeyManager.cc
+++ b/NitrokeyManager.cc
@@ -273,6 +273,21 @@ using nitrokey::misc::strcpyT;
         return device->connect();
     }
 
+    bool NitrokeyManager::connect(device::DeviceModel device_model) {
+        const char *model_string;
+        switch (device_model) {
+            case device::DeviceModel::PRO:
+                model_string = "P";
+                break;
+            case device::DeviceModel::STORAGE:
+                model_string = "S";
+                break;
+            default:
+                throw std::runtime_error("Unknown model");
+        }
+        return connect(model_string);
+    }
+
     shared_ptr<NitrokeyManager> NitrokeyManager::instance() {
       static std::mutex mutex;
       std::lock_guard<std::mutex> lock(mutex);

--- a/libnitrokey/NitrokeyManager.h
+++ b/libnitrokey/NitrokeyManager.h
@@ -80,6 +80,7 @@ char * strndup(const char* str, size_t maxlen);
         bool connect_with_ID(const std::string id);
         bool connect_with_path (std::string path);
         bool connect(const char *device_model);
+        bool connect(device::DeviceModel device_model);
         bool connect();
         bool disconnect();
         bool is_connected() throw() ;


### PR DESCRIPTION
Identifying the model to connect to by the first character of a string is not intuitive.  These patches add an overload for the connect function that accepts a `device::DeviceModel` enum value and a function `NK_login_enum` in the C API.