### PR TITLE
Correct documentation for NK_write_{hotp,totp}_slot

### DIFF
--- a/NK_C_API.h
+++ b/NK_C_API.h
@@ -190,7 +190,7 @@ extern "C" {
 	 * Write HOTP slot data to the device
 	 * @param slot_number HOTP slot number, slot_number<3
 	 * @param slot_name char[15](Pro) desired slot name
-	 * @param secret char[20](Pro) 160-bit secret
+	 * @param secret char[40](Pro) 160-bit secret as a hex string
 	 * @param hotp_counter uint32_t starting value of HOTP counter
 	 * @param use_8_digits should returned codes be 6 (false) or 8 digits (true)
 	 * @param use_enter press ENTER key after sending OTP code using double-pressed scroll/num/capslock
@@ -207,7 +207,7 @@ extern "C" {
 	 * Write TOTP slot data to the device
 	 * @param slot_number TOTP slot number, slot_number<15
 	 * @param slot_name char[15](Pro) desired slot name
-	 * @param secret char[20](Pro) 160-bit secret
+	 * @param secret char[40](Pro) 160-bit secret as a hex string
 	 * @param time_window uint16_t time window for this TOTP
 	 * @param use_8_digits should returned codes be 6 (false) or 8 digits (true)
 	 * @param use_enter press ENTER key after sending OTP code using double-pressed scroll/num/capslock


### PR DESCRIPTION
While the actual secret is 20 bytes, the functions accept a hex string. That means that every byte of the secret is represented by two bytes (characters) in the hex string.  So the argument secret for the functions `NK_write_{hotp,totp}_slot` is `char[40]`, not `char[20]`.

Two related questions:
1. Why do these functions take a hex string instead of the actual secret value? It works, but I find this counterintuitive.
2. Why is there a `(Pro)` suffix to the field types in the comment? As far as I see, they apply for both the Nitrokey Pro and the Nitrokey Storage.