### PR TITLE
Add missing enum specifier in the C API

### DIFF
--- a/NK_C_API.h
+++ b/NK_C_API.h
@@ -73,7 +73,7 @@ extern "C" {
 	 * @param device_model NK_device_model: NK_PRO: Nitrokey Pro, NK_STORAGE: Nitrokey Storage
 	 * @return 1 if connected, 0 if wrong model or cannot connect
 	 */
-        NK_C_API int NK_login_enum(NK_device_model device_model);
+        NK_C_API int NK_login_enum(enum NK_device_model device_model);
 
 	/**
 	 * Connect to first available device, starting checking from Pro 1st to Storage 2nd.


### PR DESCRIPTION
Contrary to C++, C requires the type `enum NK_device_model` instead of only `NK_device_model` when referring to the enum with that name.

I just noticed this when reading through the changes. Sorry for the miss. Can you still include this in 3.3?