### PR TITLE
Fix include path for NK_C_API.h in test_strdup.cpp

### DIFF
--- a/unittest/test_strdup.cpp
+++ b/unittest/test_strdup.cpp
@@ -25,7 +25,7 @@
 
 #include <cstdio>
 #include <memory.h>
-#include "NK_C_API.h"
+#include "../NK_C_API.h"
 #include "catch.hpp"
 
 


### PR DESCRIPTION
The test contains a wrong `#include`, leading to a compiler error if `-DCOMPILE_TESTS=1` is used.