### PR TITLE
Add set_time_soft to replace get_time

### DIFF
--- a/NK_C_API.cc
+++ b/NK_C_API.cc
@@ -360,6 +360,13 @@ extern "C" {
 		});
 	}
 
+	NK_C_API int NK_totp_set_time_soft(uint64_t time) {
+		auto m = NitrokeyManager::instance();
+		return get_without_result([&]() {
+			m->set_time_soft(time);
+		});
+        }
+
 	NK_C_API int NK_totp_get_time() {
 		auto m = NitrokeyManager::instance();
 		return get_without_result([&]() {

--- a/NK_C_API.h
+++ b/NK_C_API.h
@@ -294,6 +294,19 @@ extern "C" {
 	 */
 	NK_C_API int NK_totp_set_time(uint64_t time);
 
+	/**
+	 * Set the device time used for TOTP to the given time.  Contrary to
+	 * {@code set_time(uint64_t)}, this command fails if {@code old_time}
+	 * &gt; {@code time} or if {@code old_time} is zero (where {@code
+	 * old_time} is the current time on the device).
+	 *
+	 * @param time new device time as Unix timestamp (seconds since
+	 *        1970-01-01)
+	 * @return command processing error code
+	 */
+	NK_C_API int NK_totp_set_time_soft(uint64_t time);
+
+	/* NK_totp_get_time() is deprecated -- use NK_totp_set_time_soft */
 	NK_C_API int NK_totp_get_time();
 
 	//passwords

--- a/NitrokeyManager.cc
+++ b/NitrokeyManager.cc
@@ -666,11 +666,15 @@ using nitrokey::misc::strcpyT;
         return false;
     }
 
-    bool NitrokeyManager::get_time(uint64_t time) {
+    void NitrokeyManager::set_time_soft(uint64_t time) {
         auto p = get_payload<SetTime>();
         p.reset = 0;
         p.time = time;
         SetTime::CommandTransaction::run(device, p);
+    }
+
+    bool NitrokeyManager::get_time(uint64_t time) {
+        set_time_soft(time);
         return true;
     }
 

--- a/libnitrokey/NitrokeyManager.h
+++ b/libnitrokey/NitrokeyManager.h
@@ -65,6 +65,17 @@ char * strndup(const char* str, size_t maxlen);
         stick10::ReadSlot::ResponsePayload get_HOTP_slot_data(const uint8_t slot_number);
 
         bool set_time(uint64_t time);
+        /**
+         * Set the device time used for TOTP to the given time.  Contrary to
+         * {@code set_time(uint64_t)}, this command fails if {@code old_time}
+         * &gt; {@code time} or if {@code old_time} is zero (where {@code
+         * old_time} is the current time on the device).
+         *
+         * @param time new device time as Unix timestamp (seconds since
+         *        1970-01-01)
+         */
+        void set_time_soft(uint64_t time);
+        /* get_time is deprecated -- use set_time_soft instead */
         bool get_time(uint64_t time = 0);
         bool erase_totp_slot(uint8_t slot_number, const char *temporary_password);
         bool erase_hotp_slot(uint8_t slot_number, const char *temporary_password);


### PR DESCRIPTION
The SetTime command supports two modes: set the time without checking the currently set time, or verify that the currently set time is not zero and not larger than the new time (see [`cmd_set_time(uint8_t*, uint8_t*)` in `src/keyboard/report_protocol.c`, lines 678--710][code], in the Nitrokey Pro firmware).

`NitrokeyManager` called these two modes `set_time(uint64_t)` and `get_time(uint64_t)`, which is highly misleading – the command does never get the time.  Furthermore, the `get_time` method per default calls the command with the time zero, which will always result in an error.

The C API has the methods `NK_totp_set_time(uint64_t)` and `NK_totp_get_time()`.  `NK_totp_get_time()` calls `get_time(uint64_t)` with the time zero, leading to an error, and is therefore useless.

This patch proposes a new wording.  While it would make sense to call the first mode “reset” and the second mode “set”, this would break compatibility.  Therefore, new methods `set_time_soft(uint64_t)` and `NK_totp_set_time_soft(uint64_t)` are introduced to represent the difference between a hard and a soft setting of the time.

The old methods, `get_time(uint64_t)` and `NK_totp_get_time()`, are not removed but marked as deprecated.  They should be removed in an upcoming major release.

---

If you have a better name than `set_soft`, I am happy to adopt it!

[code]: https://github.com/Nitrokey/nitrokey-pro-firmware/blob/master/src/keyboard/report_protocol.c#L427