### PR TITLE
Correct return value for NitrokeyManager::connect()

### DIFF
--- a/NitrokeyManager.cc
+++ b/NitrokeyManager.cc
@@ -234,12 +234,14 @@ using nitrokey::misc::strcpyT;
     bool NitrokeyManager::connect() {
         std::lock_guard<std::mutex> lock(mex_dev_com_manager);
         vector< shared_ptr<Device> > devices = { make_shared<Stick10>(), make_shared<Stick20>() };
+        bool connected = false;
         for( auto & d : devices ){
             if (d->connect()){
                 device = std::shared_ptr<Device>(d);
+                connected = true;
             }
         }
-        return device != nullptr;
+        return connected;
     }
 
 


### PR DESCRIPTION
`NitrokeyManager::connect()` currently returns true if the device pointer is set.  Yet this does not mean that the connection was successful.  For example, `NitrokeyManger::connect(const char*)` sets the device pointer even if it was not successful.

This patch introduces a variable that keeps track of the connection instead of checking the device pointer.  This corrects the return value without changing the behavior of the `connect` method (returning the Storage device if both a Pro and a Storage device are present).

---

To reproduce the problem, run the following code *without* any connected device. It will fail on the second assert because the first call to `NK_login` sets the device pointer even if the connection fails.

```c
#include <assert.h>
#include <libnitrokey/NK_C_API.h>

int main()
{
	int result = 0;
	
	result = NK_login("S");
	assert(result == 0);
	
	result = NK_login_auto();
	assert(result == 0);

	return 0;
}
```

---

On a related note: Shouldn’t `connect()` fail if both a Storage and a Pro device are present?