### PR TITLE
Expose device model in C API

### DIFF
--- a/NK_C_API.cc
+++ b/NK_C_API.cc
@@ -238,6 +238,30 @@ extern "C" {
 	}
 
 
+	NK_C_API bool NK_get_device_model(enum NK_device_model *out) {
+		if (out == nullptr) {
+			return false;
+		}
+		auto m = NitrokeyManager::instance();
+		try {
+			auto model = m->get_connected_device_model();
+			switch (model) {
+				case DeviceModel::PRO:
+				    *out = NK_PRO;
+				    return true;
+				case DeviceModel::STORAGE:
+				    *out = NK_STORAGE;
+				    return true;
+				default:
+				    /* unknown device -- should not happen */
+				    return false;
+			}
+		} catch (const DeviceNotConnected& e) {
+			return false;
+		}
+        }
+
+
 	void clear_string(std::string &s) {
 		std::fill(s.begin(), s.end(), ' ');
 	}

--- a/NK_C_API.h
+++ b/NK_C_API.h
@@ -90,6 +90,17 @@ extern "C" {
 	NK_C_API int NK_logout();
 
 	/**
+	 * Query the model of the connected device.  If the out argument is
+         * NULL or if there is no connected device, this function returns
+         * false.  Otherwise it returns true and sets the target of the out
+	 * pointer to the model of the connected device.
+	 *
+	 * @param out a pointer to write the model to
+	 * @return true if a device is connected and the out argument has been set
+	 */
+	NK_C_API bool NK_get_device_model(enum NK_device_model *out);
+
+	/**
 	 * Return the debug status string. Debug purposes.
 	 * @return command processing error code
 	 */

--- a/unittest/test_C_API.cpp
+++ b/unittest/test_C_API.cpp
@@ -85,3 +85,20 @@ TEST_CASE("multiple devices with ID", "[BASIC]") {
 
   free (string);
 }
+
+TEST_CASE("Get device model", "[BASIC]") {
+    auto success = NK_get_device_model(nullptr);
+    REQUIRE(!success);
+
+    NK_logout();
+    NK_device_model model = static_cast<NK_device_model>(3);
+    success = NK_get_device_model(&model);
+    REQUIRE(!success);
+
+    auto result = NK_login_auto();
+    REQUIRE(result != 0);
+    success = NK_get_device_model(&model);
+    REQUIRE(success);
+    REQUIRE((model == NK_PRO || model == NK_STORAGE));
+    NK_logout();
+}


### PR DESCRIPTION
The C++ API already provides access to the model of the connected device in `NitrokeyManager::get_connected_device_model()`.  This patch also exposes this information in the C API by adding `NK_get_device_model`.  As there might be no device connected, the function returns a boolean indicating the connection status and writes the model of the connected device to a pointer passed as an argument.