### PR TITLE
Add getters for the library version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ IF (NOT CMAKE_BUILD_TYPE)
 ENDIF()
 MESSAGE("${PROJECT_NAME}: Build type: ${CMAKE_BUILD_TYPE}")
 
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/libnitrokey)
 include_directories(hidapi)
 include_directories(libnitrokey)
 set(SOURCE_FILES
@@ -115,7 +116,12 @@ IF (LOG_VOLATILE_DATA)
 ENDIF()
 
 
-file(GLOB LIB_INCLUDES "libnitrokey/*.h" "NK_C_API.h")
+# generate version.h
+exec_program("git" ${CMAKE_CURRENT_SOURCE_DIR} ARGS "describe --always" OUTPUT_VARIABLE PROJECT_VERSION_GIT)
+configure_file("libnitrokey/version.h.in" "libnitrokey/version.h" @ONLY)
+
+
+file(GLOB LIB_INCLUDES "libnitrokey/*.h" "NK_C_API.h" "${CMAKE_CURRENT_BINARY_DIR}/libnitrokey/version.h")
 install (FILES ${LIB_INCLUDES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
 install (TARGETS nitrokey DESTINATION ${CMAKE_INSTALL_LIBDIR})
 

--- a/NK_C_API.cc
+++ b/NK_C_API.cc
@@ -25,6 +25,7 @@
 #include <cstring>
 #include "libnitrokey/LibraryException.h"
 #include "libnitrokey/cxx_semantics.h"
+#include "version.h"
 
 #ifdef _MSC_VER
 #ifdef _WIN32
@@ -351,6 +352,18 @@ extern "C" {
 	NK_C_API void NK_set_debug_level(const int level) {
 		auto m = NitrokeyManager::instance();
 		m->set_loglevel(level);
+	}
+
+	NK_C_API unsigned int NK_get_major_library_version() {
+		return get_major_library_version();
+	}
+
+	NK_C_API unsigned int NK_get_minor_library_version() {
+		return get_minor_library_version();
+	}
+
+	NK_C_API const char* NK_get_library_version() {
+		return get_library_version();
 	}
 
 	NK_C_API int NK_totp_set_time(uint64_t time) {

--- a/NK_C_API.h
+++ b/NK_C_API.h
@@ -61,7 +61,28 @@ extern "C" {
 	 * Set debug level of messages written on stderr
 	 * @param level (int) 0-lowest verbosity, 5-highest verbosity
 	 */
-  NK_C_API void NK_set_debug_level(const int level);
+	NK_C_API void NK_set_debug_level(const int level);
+
+	/**
+	 * Get the major library version, e. g. the 3 in v3.2.
+	 * @return the major library version
+	 */
+	NK_C_API unsigned int NK_get_major_library_version();
+
+	/**
+	 * Get the minor library version, e. g. the 2 in v3.2.
+	 * @return the minor library version
+	 */
+	NK_C_API unsigned int NK_get_minor_library_version();
+
+	/**
+	 * Get the library version as a string.  This is the output of
+	 * `git describe --always` at compile time, for example "v3.3" or
+	 * "v3.3-19-gaee920b".
+	 * The return value is a string literal and must not be freed.
+	 * @return the library version as a string
+	 */
+	NK_C_API const char* NK_get_library_version();
 
 	/**
 	 * Connect to device of given model. Currently library can be connected only to one device at once.

--- a/libnitrokey/version.h.in
+++ b/libnitrokey/version.h.in
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2018 Nitrokey UG
+ *
+ * This file is part of libnitrokey.
+ *
+ * libnitrokey is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * libnitrokey is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with libnitrokey. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+ */
+
+#ifndef LIBNITROKEY_VERSION_H
+#define LIBNITROKEY_VERSION_H
+
+namespace nitrokey {
+unsigned int get_major_library_version() {
+    return @PROJECT_VERSION_MAJOR@;
+}
+
+unsigned int get_minor_library_version() {
+    return @PROJECT_VERSION_MINOR@;
+}
+
+const char* get_library_version() {
+    return "@PROJECT_VERSION_GIT@";
+}
+}
+
+#endif


### PR DESCRIPTION
CMake generates `version.h` from `version.h.in` and sets the major and minor version as specified in CMakeLists.txt and the current git version as returned by `git describe --always`.  These values are also added to the C API as `NK_get{_major,_minor,}_library_version`.

This patch fixes issue #35 and is based on the pull request #62, addressing the issues mentioned in the discussion.