### PR TITLE
Fix unit test for get_library_version for release commits

### DIFF
--- a/unittest/test_offline.cc
+++ b/unittest/test_offline.cc
@@ -22,6 +22,8 @@
 #include "catch.hpp"
 #include <NitrokeyManager.h>
 #include <memory>
+#include <string>
+#include <regex>
 #include "../NK_C_API.h"
 
 using namespace nitrokey::proto;
@@ -167,7 +169,14 @@ TEST_CASE("Test version getter", "[fast]") {
   REQUIRE(nitrokey::get_minor_library_version() >= 3u);
   const char *library_version = nitrokey::get_library_version();
   REQUIRE(library_version != nullptr);
+
+  // The library version has to match the pattern returned by git describe:
+  // v<major>.<minor> or v<major>.<minor>-<n>-g<hash>, where <n> is the number
+  // of commits since the last tag, and <hash> is the hash of the current
+  // commit.  (This assumes that all tags have the name v<major>.<minor>.)
   std::string s = library_version;
-  REQUIRE(s.length() >= 8);
-  REQUIRE(s.find("g") != std::string::npos);
+  std::string version("v[0-9]+\\.[0-9]+");
+  std::string git_suffix("-[0-9]+-g[0-9a-z]+");
+  std::regex pattern(version + "(" + git_suffix + "|)");
+  REQUIRE(std::regex_match(s, pattern));
 }


### PR DESCRIPTION
`git describe` may return a tag name or `<tag>-<n>-g<hash>`, where *n* is the number of commits since the last tag *tag* and *hash* is the hash of the current commit.  The current test case only considers the latter case.  This patch adds a regular expression to handle both cases.

Fixes #121.

---

To test the regular expression, you can use this snippet:

```c++
#include <iostream>
#include <regex>
#include <string>
#include <vector>

int main(int argc, char** argv) {
    std::string version("v[0-9]+\\.[0-9]+");
    std::string git_suffix("-[0-9]+-g[0-9a-z]+");
    std::regex r(version + "(" + git_suffix + "|)");

    std::vector<std::string> correct = {"v3.3", "v4.51", "v3.3-31-ge1ef8d7"};
    std::vector<std::string> not_correct =
        {"v3.1.3", "v3.1.3-pre", "alpha-v3.4", "v4.4.4-ge1e4d8d7",
         "v3.1.3-31-e1ef8d7", "v3.3-31-ge1ef8d7-beta"};
    
    std::cout << "Testing correct versions:\n";
    for (const auto& s : correct) {
        std::cout << s << ": \t" << std::regex_match(s, r) << "\n";
    }
    
    std::cout << "Testing incorrect versions:\n";
    for (const auto& s : not_correct) {
        std::cout << s << ": \t" << std::regex_match(s, r) << "\n";
    }

    return 0;
}
```