### PR TITLE
Replace deprecated attribute in C API with a comment

### DIFF
--- a/NK_C_API.h
+++ b/NK_C_API.h
@@ -417,7 +417,7 @@ extern "C" {
 	 */
 	NK_C_API int NK_totp_set_time_soft(uint64_t time);
 
-  [[deprecated("NK_totp_get_time is deprecated -- use NK_totp_set_time_soft instead")]]
+	// NK_totp_get_time is deprecated -- use NK_totp_set_time_soft instead
 	NK_C_API int NK_totp_get_time();
 
 	//passwords


### PR DESCRIPTION
Attribute specifiers are a C++-only feature.  Therefore this patch removes the `[[deprecated(...)]]` attribute from the `NK_totp_get_time` method in `NK_C_API.h` and replaces it with a comment.