### PR TITLE
Add a test to ensure valid C code in the C API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,10 @@ IF(COMPILE_OFFLINE_TESTS)
     #run with 'make test' or 'ctest'
     include (CTest)
     add_test (runs test_offline)
+
+    add_executable(test_minimal unittest/test_minimal.c)
+    target_link_libraries(test_minimal ${EXTRA_LIBS} nitrokey)
+    add_test(minimal test_minimal)
 ENDIF()
 
 IF (COMPILE_TESTS)

--- a/unittest/test_minimal.c
+++ b/unittest/test_minimal.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2018 Nitrokey UG
+ *
+ * This file is part of libnitrokey.
+ *
+ * libnitrokey is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * libnitrokey is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with libnitrokey. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+ */
+
+#include "../NK_C_API.h"
+
+// This test is only intended to make sure that the C API header can be
+// compiled by a C compiler.  (All other tests are written in C++.)
+int main() {
+	return 0;
+}


### PR DESCRIPTION
All current tests are written in C++.  Therefore C++-only code in the C API might not be detected by the tests.  This patch adds a minimal test written in C that only includes the C API header.  This should make sure that the C API code is valid.

The new test is called `test_minimal.c` and is added to the CMake `COMPILE_OFFLINE_TESTS` option.

See also issue #109.