### PR TITLE
Update for compatibility with Catch2 version 2.3.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "unittest/Catch"]
 	path = unittest/Catch
-	url = https://github.com/philsquared/Catch.git
+	url = https://github.com/catchorg/Catch2.git
 [submodule "hidapi"]
 	path = hidapi
 	url = https://github.com/Nitrokey/hidapi.git

--- a/meson.build
+++ b/meson.build
@@ -120,7 +120,7 @@ install_data(
 )
 
 if get_option('tests') or get_option('offline-tests')
-  dep_catch = dependency('catch', required : false)
+  dep_catch = dependency('catch2', version : '>=2.3.0', required : false)
   if not dep_catch.found()
     dep_catch = declare_dependency(
       include_directories : include_directories('unittest/Catch/single_include')

--- a/unittest/catch_main.cpp
+++ b/unittest/catch_main.cpp
@@ -20,4 +20,4 @@
  */
 
 #define CATCH_CONFIG_MAIN  // This tells Catch to provide a main()
-#include "catch.hpp"
+#include "catch2/catch.hpp"

--- a/unittest/test1.cc
+++ b/unittest/test1.cc
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: LGPL-3.0
  */
 
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 #include <iostream>
 #include <string.h>

--- a/unittest/test2.cc
+++ b/unittest/test2.cc
@@ -23,7 +23,7 @@
 static const char *const default_admin_pin = "12345678";
 static const char *const default_user_pin = "123456";
 
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 #include <iostream>
 #include <string.h>

--- a/unittest/test3.cc
+++ b/unittest/test3.cc
@@ -25,7 +25,7 @@ static const char *const default_user_pin = "123456";
 const char * temporary_password = "123456789012345678901234";
 const char * RFC_SECRET = "12345678901234567890";
 
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 #include <iostream>
 #include <string.h>

--- a/unittest/test_C_API.cpp
+++ b/unittest/test_C_API.cpp
@@ -21,7 +21,7 @@
 
 static const int TOO_LONG_STRING = 200;
 
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 #include <iostream>
 #include <string>

--- a/unittest/test_HOTP.cc
+++ b/unittest/test_HOTP.cc
@@ -20,7 +20,7 @@
  */
 
 
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 #include <iostream>
 #include "device_proto.h"
 #include "log.h"

--- a/unittest/test_issues.cc
+++ b/unittest/test_issues.cc
@@ -26,7 +26,7 @@ const char * const temporary_password = "123456789012345678901234";
 const char * const RFC_SECRET = "12345678901234567890";
 const char * const hidden_volume_pass = "123456789012345";
 
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 #include <NitrokeyManager.h>
 

--- a/unittest/test_multiple_devices.cc
+++ b/unittest/test_multiple_devices.cc
@@ -24,7 +24,7 @@ static const char *const default_user_pin = "123456";
 const char * temporary_password = "123456789012345678901234";
 const char * RFC_SECRET = "12345678901234567890";
 
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 #include <iostream>
 #include <NitrokeyManager.h>

--- a/unittest/test_offline.cc
+++ b/unittest/test_offline.cc
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: LGPL-3.0
  */
 
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 #include <NitrokeyManager.h>
 #include <memory>
 #include <string>

--- a/unittest/test_strdup.cpp
+++ b/unittest/test_strdup.cpp
@@ -26,7 +26,7 @@
 #include <cstdio>
 #include <memory.h>
 #include "../NK_C_API.h"
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 
 static const int SHORT_STRING_LENGTH = 10;


### PR DESCRIPTION
Per https://github.com/catchorg/Catch2/releases/tag/v2.3.0 the pkg-config module name and include path have changed in 2.3.0 and later.