### PR TITLE
Add Nitrokey FIDO U2F entry

### DIFF
--- a/data/41-nitrokey.rules
+++ b/data/41-nitrokey.rules
@@ -26,7 +26,7 @@ ACTION!="add|change", GOTO="u2f_end"
 # Nitrokey U2F
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="f1d0", MODE="0664", GROUP+="plugdev", TAG+="uaccess"
 # Nitrokey FIDO U2F
-KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4287", GROUP+="plugdev", TAG+="uaccess"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4287", MODE="0660", GROUP+="plugdev", TAG+="uaccess"
 
 LABEL="u2f_end"
 

--- a/data/41-nitrokey.rules
+++ b/data/41-nitrokey.rules
@@ -19,8 +19,10 @@
 # SPDX-License-Identifier: LGPL-3.0
 #
 
-
-# this udev file should be used with udev 188 and newer
+# Here rules in new style should be provided. Matching devices should be tagged with 'uaccess'.
+# File prefix number should be lower than 73, to be correctly processed by the Udev.
+# Recommended udev version: >= 188.
+#
 ACTION!="add|change", GOTO="u2f_end"
 
 # Nitrokey U2F

--- a/data/41-nitrokey.rules
+++ b/data/41-nitrokey.rules
@@ -24,9 +24,9 @@
 ACTION!="add|change", GOTO="u2f_end"
 
 # Nitrokey U2F
-KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="f1d0", MODE="0664", GROUP+="plugdev", TAG+="uaccess"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="f1d0", TAG+="uaccess"
 # Nitrokey FIDO U2F
-KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4287", MODE="0660", GROUP+="plugdev", TAG+="uaccess"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4287", TAG+="uaccess"
 
 LABEL="u2f_end"
 
@@ -36,15 +36,15 @@ ACTION!="add", GOTO="gnupg_rules_end"
 
 # USB SmartCard Readers
 ## Crypto Stick 1.2
-ATTR{idVendor}=="20a0", ATTR{idProduct}=="4107", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", GROUP+="plugdev", TAG+="uaccess"
+ATTR{idVendor}=="20a0", ATTR{idProduct}=="4107", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", TAG+="uaccess"
 ## Nitrokey Pro
-ATTR{idVendor}=="20a0", ATTR{idProduct}=="4108", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", GROUP+="plugdev", TAG+="uaccess"
+ATTR{idVendor}=="20a0", ATTR{idProduct}=="4108", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", TAG+="uaccess"
 ## Nitrokey Storage
-ATTR{idVendor}=="20a0", ATTR{idProduct}=="4109", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", GROUP+="plugdev", TAG+="uaccess"
+ATTR{idVendor}=="20a0", ATTR{idProduct}=="4109", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", TAG+="uaccess"
 ## Nitrokey Start
-ATTR{idVendor}=="20a0", ATTR{idProduct}=="4211", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", GROUP+="plugdev", TAG+="uaccess"
+ATTR{idVendor}=="20a0", ATTR{idProduct}=="4211", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", TAG+="uaccess"
 ## Nitrokey HSM
-ATTR{idVendor}=="20a0", ATTR{idProduct}=="4230", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", GROUP+="plugdev", TAG+="uaccess"
+ATTR{idVendor}=="20a0", ATTR{idProduct}=="4230", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", TAG+="uaccess"
 
 LABEL="gnupg_rules_end"
 

--- a/data/41-nitrokey.rules
+++ b/data/41-nitrokey.rules
@@ -1,7 +1,35 @@
+#
+# Copyright (c) 2015-2019 Nitrokey UG
+#
+# This file is part of libnitrokey.
+#
+# libnitrokey is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# libnitrokey is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with libnitrokey. If not, see <http://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: LGPL-3.0
+#
+
+
+# this udev file should be used with udev 188 and newer
+ACTION!="add|change", GOTO="u2f_end"
+
 # Nitrokey U2F
-KERNEL=="hidraw*", SUBSYSTEM=="hidraw", MODE="0664", GROUP="plugdev", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="f1d0"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="f1d0", MODE="0664", GROUP+="plugdev", TAG+="uaccess"
 # Nitrokey FIDO U2F
-KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4287", TAG+="uaccess"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4287", GROUP+="plugdev", TAG+="uaccess"
+
+LABEL="u2f_end"
+
 
 SUBSYSTEM!="usb", GOTO="gnupg_rules_end"
 ACTION!="add", GOTO="gnupg_rules_end"

--- a/data/41-nitrokey.rules
+++ b/data/41-nitrokey.rules
@@ -1,5 +1,7 @@
 # Nitrokey U2F
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", MODE="0664", GROUP="plugdev", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="f1d0"
+# Nitrokey FIDO U2F
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4287", TAG+="uaccess"
 
 SUBSYSTEM!="usb", GOTO="gnupg_rules_end"
 ACTION!="add", GOTO="gnupg_rules_end"

--- a/data/41-nitrokey_old.rules
+++ b/data/41-nitrokey_old.rules
@@ -39,15 +39,15 @@ ACTION!="add", GOTO="gnupg_rules_end"
 
 # USB SmartCard Readers
 ## Crypto Stick 1.2
-ATTR{idVendor}=="20a0", ATTR{idProduct}=="4107", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", GROUP+="plugdev", TAG+="uaccess"
+ATTR{idVendor}=="20a0", ATTR{idProduct}=="4107", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", MODE="0660", GROUP+="plugdev"
 ## Nitrokey Pro
-ATTR{idVendor}=="20a0", ATTR{idProduct}=="4108", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", GROUP+="plugdev", TAG+="uaccess"
+ATTR{idVendor}=="20a0", ATTR{idProduct}=="4108", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", MODE="0660", GROUP+="plugdev"
 ## Nitrokey Storage
-ATTR{idVendor}=="20a0", ATTR{idProduct}=="4109", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", GROUP+="plugdev", TAG+="uaccess"
+ATTR{idVendor}=="20a0", ATTR{idProduct}=="4109", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", MODE="0660", GROUP+="plugdev"
 ## Nitrokey Start
-ATTR{idVendor}=="20a0", ATTR{idProduct}=="4211", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", GROUP+="plugdev", TAG+="uaccess"
+ATTR{idVendor}=="20a0", ATTR{idProduct}=="4211", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", MODE="0660", GROUP+="plugdev"
 ## Nitrokey HSM
-ATTR{idVendor}=="20a0", ATTR{idProduct}=="4230", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", GROUP+="plugdev", TAG+="uaccess"
+ATTR{idVendor}=="20a0", ATTR{idProduct}=="4230", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", MODE="0660", GROUP+="plugdev"
 
 LABEL="gnupg_rules_end"
 

--- a/data/41-nitrokey_old.rules
+++ b/data/41-nitrokey_old.rules
@@ -1,0 +1,53 @@
+#
+# Copyright (c) 2015-2019 Nitrokey UG
+#
+# This file is part of libnitrokey.
+#
+# libnitrokey is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# libnitrokey is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with libnitrokey. If not, see <http://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: LGPL-3.0
+#
+
+
+# this udev file should be used with udev 188 and newer
+ACTION!="add|change", GOTO="u2f_end"
+
+# Nitrokey U2F
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="f1d0", MODE="0664", GROUP+="plugdev"
+# Nitrokey FIDO U2F
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4287", MODE="0660", GROUP+="plugdev"
+
+LABEL="u2f_end"
+
+
+SUBSYSTEM!="usb", GOTO="gnupg_rules_end"
+ACTION!="add", GOTO="gnupg_rules_end"
+
+# USB SmartCard Readers
+## Crypto Stick 1.2
+ATTR{idVendor}=="20a0", ATTR{idProduct}=="4107", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", GROUP+="plugdev", TAG+="uaccess"
+## Nitrokey Pro
+ATTR{idVendor}=="20a0", ATTR{idProduct}=="4108", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", GROUP+="plugdev", TAG+="uaccess"
+## Nitrokey Storage
+ATTR{idVendor}=="20a0", ATTR{idProduct}=="4109", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", GROUP+="plugdev", TAG+="uaccess"
+## Nitrokey Start
+ATTR{idVendor}=="20a0", ATTR{idProduct}=="4211", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", GROUP+="plugdev", TAG+="uaccess"
+## Nitrokey HSM
+ATTR{idVendor}=="20a0", ATTR{idProduct}=="4230", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", GROUP+="plugdev", TAG+="uaccess"
+
+LABEL="gnupg_rules_end"
+
+
+# Nitrokey Storage dev Entry
+KERNEL=="sd?1", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4109", SYMLINK+="nitrospace"

--- a/data/41-nitrokey_old.rules
+++ b/data/41-nitrokey_old.rules
@@ -19,8 +19,11 @@
 # SPDX-License-Identifier: LGPL-3.0
 #
 
-
-# this udev file should be used with udev 188 and newer
+# Here rules in old style should be provided. Matching devices should be added to 'plugdev' group,
+# and with mode set to "0660".
+# File prefix number should be lower than 73, to be correctly processed by the Udev.
+# Recommended udev version: < 188.
+#
 ACTION!="add|change", GOTO="u2f_end"
 
 # Nitrokey U2F

--- a/data/41-nitrokey_old.rules
+++ b/data/41-nitrokey_old.rules
@@ -27,7 +27,7 @@
 ACTION!="add|change", GOTO="u2f_end"
 
 # Nitrokey U2F
-KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="f1d0", MODE="0664", GROUP+="plugdev"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="f1d0", MODE="0660", GROUP+="plugdev"
 # Nitrokey FIDO U2F
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4287", MODE="0660", GROUP+="plugdev"
 


### PR DESCRIPTION
This entry for the Nitrokey FIDO U2F is the same like in [libu2f-host](https://github.com/Yubico/libu2f-host/blob/master/70-u2f.rules) and is working just fine. It should be enough to install libnitrokey to get the device working in the future.

See [this discussion](https://support.nitrokey.com/t/problems-with-nitrokey-fido-u2f/1553) as well.