### PR TITLE
Improve support for multiple devices

### DIFF
--- a/NK_C_API.cc
+++ b/NK_C_API.cc
@@ -743,6 +743,14 @@ NK_C_API char* NK_get_SD_usage_data_as_string() {
 		});
 	}
 
+	NK_C_API int NK_connect_with_path(const char* path) {
+		auto m = NitrokeyManager::instance();
+		return get_with_result([&]() {
+			return m->connect_with_path(path) ? 1 : 0;
+		});
+	 }
+
+
 	NK_C_API int NK_wink() {
 		auto m = NitrokeyManager::instance();
 		return get_without_result([&]() {

--- a/NK_C_API.cc
+++ b/NK_C_API.cc
@@ -736,6 +736,66 @@ NK_C_API char* NK_get_SD_usage_data_as_string() {
 		});
 	}
 
+	bool copy_device_info(const DeviceInfo& source, NK_device_info* target) {
+		switch (source.m_deviceModel) {
+		case DeviceModel::PRO:
+			target->model = NK_PRO;
+			break;
+		case DeviceModel::STORAGE:
+			target->model = NK_STORAGE;
+			break;
+		default:
+			return false;
+		}
+
+		target->path = strndup(source.m_path.c_str(), MAXIMUM_STR_REPLY_LENGTH);
+		target->serial_number = strndup(source.m_serialNumber.c_str(), MAXIMUM_STR_REPLY_LENGTH);
+		target->next = nullptr;
+
+		return target->path && target->serial_number;
+	}
+
+	NK_C_API struct NK_device_info* NK_list_devices() {
+		auto nm = NitrokeyManager::instance();
+		return get_with_result([&]() -> NK_device_info* {
+			auto v = nm->list_devices();
+			if (v.empty())
+				return nullptr;
+
+			auto result = new NK_device_info();
+			auto ptr = result;
+			auto first = v.begin();
+			if (!copy_device_info(*first, ptr)) {
+				NK_free_device_info(result);
+				return nullptr;
+			}
+			v.erase(first);
+
+			for (auto& info : v) {
+				ptr->next = new NK_device_info();
+				ptr = ptr->next;
+
+				if (!copy_device_info(info, ptr)) {
+					NK_free_device_info(result);
+					return nullptr;
+				}
+			}
+			return result;
+		});
+	}
+
+	NK_C_API void NK_free_device_info(struct NK_device_info* device_info) {
+		if (!device_info)
+			return;
+
+		if (device_info->next)
+			NK_free_device_info(device_info->next);
+
+		free(device_info->path);
+		free(device_info->serial_number);
+		delete device_info;
+	}
+
 	NK_C_API int NK_connect_with_ID(const char* id) {
 		auto m = NitrokeyManager::instance();
 		return get_with_result([&]() {

--- a/NK_C_API.h
+++ b/NK_C_API.h
@@ -780,6 +780,14 @@ extern "C" {
 	NK_C_API int NK_connect_with_ID(const char* id);
 
 	/**
+	 * Connects to a device with the given path.  The path is a USB device
+	 * path as returned by hidapi.
+	 * @param path the device path
+	 * @return 1 on successful connection, 0 otherwise
+	 */
+        NK_C_API int NK_connect_with_path(const char* path);
+
+	/**
 	 * Blink red and green LED alternatively and infinitely (until device is reconnected).
 	 * @return command processing error code
 	 */

--- a/NK_C_API.h
+++ b/NK_C_API.h
@@ -57,6 +57,29 @@ extern "C" {
             NK_STORAGE = 2
         };
 
+        /**
+	 * The connection info for a Nitrokey device as a linked list.
+	 */
+	struct NK_device_info {
+		/**
+		 * The model of the Nitrokey device.
+		 */
+		enum NK_device_model model;
+		/**
+		 * The USB device path for NK_connect_with_path.
+		 */
+		char* path;
+		/**
+		 * The serial number.
+		 */
+		char* serial_number;
+		/**
+		 * The pointer to the next element of the linked list or null
+		 * if this is the last element in the list.
+		 */
+		struct NK_device_info* next;
+	};
+
 	/**
 	 * Stores the status of a Storage device.
 	 */
@@ -768,6 +791,19 @@ extern "C" {
  */
 	NK_C_API char* NK_list_devices_by_cpuID();
 
+	/**
+	 * Returns a linked list of all connected devices, or null if no devices
+	 * are connected or an error occured.  The linked list must be freed by
+	 * calling NK_free_device_info.
+	 * @return a linked list of all connected devices
+	 */
+	NK_C_API struct NK_device_info* NK_list_devices();
+
+	/**
+	 * Free a linked list returned by NK_list_devices.
+	 * @param the linked list to free or null
+	 */
+	NK_C_API void NK_free_device_info(struct NK_device_info* device_info);
 
 /**
  * Connects to the device with given ID. ID's list could be created with NK_list_devices_by_cpuID.

--- a/NitrokeyManager.cc
+++ b/NitrokeyManager.cc
@@ -108,8 +108,7 @@ using nitrokey::misc::strcpyT;
     std::vector<DeviceInfo> NitrokeyManager::list_devices(){
         std::lock_guard<std::mutex> lock(mex_dev_com_manager);
 
-        auto p = make_shared<Stick20>();
-        return p->enumerate();
+        return Device::enumerate();
     }
 
     std::vector<std::string> NitrokeyManager::list_devices_by_cpuID(){
@@ -127,12 +126,13 @@ using nitrokey::misc::strcpyT;
 
         LOGD1("Enumerating devices");
         std::vector<std::string> res;
-        auto d = make_shared<Stick20>();
-        const auto v = d->enumerate();
+        const auto v = Device::enumerate();
         LOGD1("Discovering IDs");
         for (auto & i: v){
+            if (i.m_deviceModel != DeviceModel::STORAGE)
+                continue;
             auto p = i.m_path;
-            d = make_shared<Stick20>();
+            auto d = make_shared<Stick20>();
             LOGD1( std::string("Found: ") + p );
             d->set_path(p);
             try{

--- a/NitrokeyManager.cc
+++ b/NitrokeyManager.cc
@@ -109,7 +109,12 @@ using nitrokey::misc::strcpyT;
         std::lock_guard<std::mutex> lock(mex_dev_com_manager);
 
         auto p = make_shared<Stick20>();
-        return p->enumerate(); // make static
+        auto device_infos = p->enumerate();
+        std::vector<std::string> strings;
+        strings.resize(device_infos.size());
+        std::transform(device_infos.begin(), device_infos.end(), strings.begin(),
+            [](auto device_info) { return device_info.m_path; });
+        return strings;
     }
 
     std::vector<std::string> NitrokeyManager::list_devices_by_cpuID(){
@@ -130,7 +135,8 @@ using nitrokey::misc::strcpyT;
         auto d = make_shared<Stick20>();
         const auto v = d->enumerate();
         LOGD1("Discovering IDs");
-        for (auto & p: v){
+        for (auto & i: v){
+            auto p = i.m_path;
             d = make_shared<Stick20>();
             LOGD1( std::string("Found: ") + p );
             d->set_path(p);

--- a/NitrokeyManager.cc
+++ b/NitrokeyManager.cc
@@ -105,16 +105,11 @@ using nitrokey::misc::strcpyT;
       return true;
     }
 
-    std::vector<std::string> NitrokeyManager::list_devices(){
+    std::vector<DeviceInfo> NitrokeyManager::list_devices(){
         std::lock_guard<std::mutex> lock(mex_dev_com_manager);
 
         auto p = make_shared<Stick20>();
-        auto device_infos = p->enumerate();
-        std::vector<std::string> strings;
-        strings.resize(device_infos.size());
-        std::transform(device_infos.begin(), device_infos.end(), strings.begin(),
-            [](auto device_info) { return device_info.m_path; });
-        return strings;
+        return p->enumerate();
     }
 
     std::vector<std::string> NitrokeyManager::list_devices_by_cpuID(){

--- a/device.cc
+++ b/device.cc
@@ -20,7 +20,9 @@
  */
 
 #include <chrono>
+#include <codecvt>
 #include <iostream>
+#include <locale>
 #include <thread>
 #include <cstddef>
 #include <stdexcept>
@@ -210,7 +212,9 @@ std::vector<DeviceInfo> Device::enumerate(){
     auto deviceModel = product_id_to_model(pInfo->product_id);
     if (deviceModel.has_value()) {
       std::string path(pInfo->path);
-      std::wstring serialNumber(pInfo->serial_number);
+      std::wstring serialNumberW(pInfo->serial_number);
+      std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+      std::string serialNumber = converter.to_bytes(serialNumberW);
       DeviceInfo info = { deviceModel.value(), path, serialNumber };
       res.push_back(info);
     }

--- a/device.cc
+++ b/device.cc
@@ -57,6 +57,21 @@ Option<DeviceModel> nitrokey::device::product_id_to_model(uint16_t product_id) {
 std::atomic_int Device::instances_count{0};
 std::chrono::milliseconds Device::default_delay {0} ;
 
+std::ostream& nitrokey::device::operator<<(std::ostream& stream, DeviceModel model) {
+  switch (model) {
+    case DeviceModel::PRO:
+      stream << "Pro";
+      break;
+    case DeviceModel::STORAGE:
+      stream << "Storage";
+      break;
+    default:
+      stream << "Unknown";
+      break;
+  }
+  return stream;
+}
+
 Device::Device(const uint16_t vid, const uint16_t pid, const DeviceModel model,
                const milliseconds send_receive_delay, const int retry_receiving_count,
                const milliseconds retry_timeout)

--- a/device.cc
+++ b/device.cc
@@ -36,11 +36,23 @@ std::mutex mex_dev_com;
 
 using namespace nitrokey::device;
 using namespace nitrokey::log;
+using namespace nitrokey::misc;
 using namespace std::chrono;
 
 const uint16_t nitrokey::device::NITROKEY_VID = 0x20a0;
 const uint16_t nitrokey::device::NITROKEY_PRO_PID = 0x4108;
 const uint16_t nitrokey::device::NITROKEY_STORAGE_PID = 0x4109;
+
+Option<DeviceModel> nitrokey::device::product_id_to_model(uint16_t product_id) {
+  switch (product_id) {
+    case NITROKEY_PRO_PID:
+      return DeviceModel::PRO;
+    case NITROKEY_STORAGE_PID:
+      return DeviceModel::STORAGE;
+    default:
+      return {};
+  }
+}
 
 std::atomic_int Device::instances_count{0};
 std::chrono::milliseconds Device::default_delay {0} ;

--- a/device.cc
+++ b/device.cc
@@ -188,16 +188,17 @@ int Device::recv(void *packet) {
 }
 
 std::vector<DeviceInfo> Device::enumerate(){
-  //TODO make static
-  auto pInfo = hid_enumerate(m_vid, m_pid);
+  auto pInfo = hid_enumerate(NITROKEY_VID, 0);
   auto pInfo_ = pInfo;
   std::vector<DeviceInfo> res;
   while (pInfo != nullptr){
-    std::string path(pInfo->path);
-    std::wstring serialNumber(pInfo->serial_number);
-    auto deviceModel = this->get_device_model();
-    DeviceInfo info = { deviceModel, path, serialNumber };
-    res.push_back(info);
+    auto deviceModel = product_id_to_model(pInfo->product_id);
+    if (deviceModel.has_value()) {
+      std::string path(pInfo->path);
+      std::wstring serialNumber(pInfo->serial_number);
+      DeviceInfo info = { deviceModel.value(), path, serialNumber };
+      res.push_back(info);
+    }
     pInfo = pInfo->next;
   }
 

--- a/device.cc
+++ b/device.cc
@@ -209,6 +209,17 @@ std::vector<DeviceInfo> Device::enumerate(){
   return res;
 }
 
+std::shared_ptr<Device> Device::create(DeviceModel model) {
+  switch (model) {
+    case DeviceModel::PRO:
+      return std::make_shared<Stick10>();
+    case DeviceModel::STORAGE:
+      return std::make_shared<Stick20>();
+    default:
+      return {};
+  }
+}
+
 bool Device::could_be_enumerated() {
   LOG(__FUNCTION__, Loglevel::DEBUG_L2);
   std::lock_guard<std::mutex> lock(mex_dev_com);

--- a/device.cc
+++ b/device.cc
@@ -171,14 +171,17 @@ int Device::recv(void *packet) {
   return status;
 }
 
-std::vector<std::string> Device::enumerate(){
+std::vector<DeviceInfo> Device::enumerate(){
   //TODO make static
   auto pInfo = hid_enumerate(m_vid, m_pid);
   auto pInfo_ = pInfo;
-  std::vector<std::string> res;
+  std::vector<DeviceInfo> res;
   while (pInfo != nullptr){
-    std::string a (pInfo->path);
-    res.push_back(a);
+    std::string path(pInfo->path);
+    std::wstring serialNumber(pInfo->serial_number);
+    auto deviceModel = this->get_device_model();
+    DeviceInfo info = { deviceModel, path, serialNumber };
+    res.push_back(info);
     pInfo = pInfo->next;
   }
 

--- a/device.cc
+++ b/device.cc
@@ -38,6 +38,10 @@ using namespace nitrokey::device;
 using namespace nitrokey::log;
 using namespace std::chrono;
 
+const uint16_t nitrokey::device::NITROKEY_VID = 0x20a0;
+const uint16_t nitrokey::device::NITROKEY_PRO_PID = 0x4108;
+const uint16_t nitrokey::device::NITROKEY_STORAGE_PID = 0x4109;
+
 std::atomic_int Device::instances_count{0};
 std::chrono::milliseconds Device::default_delay {0} ;
 
@@ -246,14 +250,14 @@ void Device::set_retry_delay(const std::chrono::milliseconds delay){
 }
 
 Stick10::Stick10():
-  Device(0x20a0, 0x4108, DeviceModel::PRO, 100ms, 5, 100ms)
+  Device(NITROKEY_VID, NITROKEY_PRO_PID, DeviceModel::PRO, 100ms, 5, 100ms)
   {
     setDefaultDelay();
   }
 
 
 Stick20::Stick20():
-  Device(0x20a0, 0x4109, DeviceModel::STORAGE, 40ms, 55, 40ms)
+  Device(NITROKEY_VID, NITROKEY_STORAGE_PID, DeviceModel::STORAGE, 40ms, 55, 40ms)
   {
     setDefaultDelay();
   }

--- a/libnitrokey/NitrokeyManager.h
+++ b/libnitrokey/NitrokeyManager.h
@@ -80,7 +80,7 @@ char * strndup(const char* str, size_t maxlen);
         bool get_time(uint64_t time = 0);
         bool erase_totp_slot(uint8_t slot_number, const char *temporary_password);
         bool erase_hotp_slot(uint8_t slot_number, const char *temporary_password);
-        std::vector<std::string> list_devices();
+        std::vector<DeviceInfo> list_devices();
         std::vector<std::string> list_devices_by_cpuID();
 
         /**

--- a/libnitrokey/device.h
+++ b/libnitrokey/device.h
@@ -148,12 +148,11 @@ public:
    */
   bool could_be_enumerated();
   /**
-   * Returns a vector with all connected Nitrokey devices of the same device
-   * type as this device.
+   * Returns a vector with all connected Nitrokey devices.
    *
    * @return information about all connected devices
    */
-  std::vector<DeviceInfo> enumerate();
+  static std::vector<DeviceInfo> enumerate();
 
 
         void show_stats();

--- a/libnitrokey/device.h
+++ b/libnitrokey/device.h
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <ostream>
 #include <vector>
 #include "misc.h"
 
@@ -51,6 +52,8 @@ enum class DeviceModel{
     PRO,
     STORAGE
 };
+
+std::ostream& operator<<(std::ostream& stream, DeviceModel model);
 
 /**
  * The USB vendor ID for Nitrokey devices.

--- a/libnitrokey/device.h
+++ b/libnitrokey/device.h
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include "misc.h"
 
 #define HID_REPORT_SIZE 65
 
@@ -62,6 +63,12 @@ extern const uint16_t NITROKEY_PRO_PID;
  * The USB product ID for the Nitrokey Storage.
  */
 extern const uint16_t NITROKEY_STORAGE_PID;
+
+/**
+ * Convert the given USB product ID to a Nitrokey model.  If there is no model
+ * with that ID, return an absent value.
+ */
+misc::Option<DeviceModel> product_id_to_model(uint16_t product_id);
 
 /**
  * Information about a connected device.

--- a/libnitrokey/device.h
+++ b/libnitrokey/device.h
@@ -127,7 +127,13 @@ public:
    * @return true if visible by OS
    */
   bool could_be_enumerated();
-  std::vector<std::string> enumerate();
+  /**
+   * Returns a vector with all connected Nitrokey devices of the same device
+   * type as this device.
+   *
+   * @return information about all connected devices
+   */
+  std::vector<DeviceInfo> enumerate();
 
 
         void show_stats();

--- a/libnitrokey/device.h
+++ b/libnitrokey/device.h
@@ -51,6 +51,19 @@ enum class DeviceModel{
 };
 
 /**
+ * The USB vendor ID for Nitrokey devices.
+ */
+extern const uint16_t NITROKEY_VID;
+/**
+ * The USB product ID for the Nitrokey Pro.
+ */
+extern const uint16_t NITROKEY_PRO_PID;
+/**
+ * The USB product ID for the Nitrokey Storage.
+ */
+extern const uint16_t NITROKEY_STORAGE_PID;
+
+/**
  * Information about a connected device.
  *
  * This struct contains the information about a connected device returned by

--- a/libnitrokey/device.h
+++ b/libnitrokey/device.h
@@ -24,6 +24,7 @@
 #include <chrono>
 #include "hidapi/hidapi.h"
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 #include "misc.h"
@@ -153,6 +154,11 @@ public:
    * @return information about all connected devices
    */
   static std::vector<DeviceInfo> enumerate();
+
+  /**
+   * Create a Device of the given model.
+   */
+  static std::shared_ptr<Device> create(DeviceModel model);
 
 
         void show_stats();

--- a/libnitrokey/device.h
+++ b/libnitrokey/device.h
@@ -50,6 +50,27 @@ enum class DeviceModel{
     STORAGE
 };
 
+/**
+ * Information about a connected device.
+ *
+ * This struct contains the information about a connected device returned by
+ * hidapi when enumerating the connected devices.
+ */
+struct DeviceInfo {
+    /**
+     * The model of the connected device.
+     */
+    DeviceModel m_deviceModel;
+    /**
+     * The USB connection path for the device.
+     */
+    std::string m_path;
+    /**
+     * The serial number of the device.
+     */
+    std::wstring m_serialNumber;
+};
+
 #include <atomic>
 
 class Device {

--- a/libnitrokey/device.h
+++ b/libnitrokey/device.h
@@ -92,7 +92,7 @@ struct DeviceInfo {
     /**
      * The serial number of the device.
      */
-    std::wstring m_serialNumber;
+    std::string m_serialNumber;
 };
 
 #include <atomic>

--- a/libnitrokey/misc.h
+++ b/libnitrokey/misc.h
@@ -29,11 +29,36 @@
 #include "log.h"
 #include "LibraryException.h"
 #include <sstream>
+#include <stdexcept>
 #include <iomanip>
 
 
 namespace nitrokey {
 namespace misc {
+
+/**
+ * Simple replacement for std::optional (C++17).
+ */
+template<typename T>
+class Option {
+public:
+    Option() : m_hasValue(false), m_value() {}
+    Option(T value) : m_hasValue(true), m_value(value) {}
+
+    bool has_value() const {
+        return m_hasValue;
+    }
+    T value() const {
+        if (!m_hasValue) {
+            throw std::logic_error("Called Option::value without value");
+        }
+        return m_value;
+    }
+
+private:
+    bool m_hasValue;
+    T m_value;
+};
 
     template<typename T>
     std::string toHex(T value){

--- a/unittest/test_multiple.py
+++ b/unittest/test_multiple.py
@@ -29,9 +29,17 @@ from tqdm import tqdm
 
 from conftest import skip_if_device_version_lower_than
 from constants import DefaultPasswords, DeviceErrorCode, bb
-from misc import gs, wait
+from misc import gs, wait, ffi
 
 pprint = pprint.PrettyPrinter(indent=4).pprint
+
+
+@pytest.mark.other
+@pytest.mark.info
+def test_list_devices(C):
+    infos = C.NK_list_devices()
+    assert infos != ffi.NULL
+    C.NK_free_device_info(infos)
 
 
 @pytest.mark.other

--- a/unittest/test_multiple.py
+++ b/unittest/test_multiple.py
@@ -44,6 +44,25 @@ def test_list_devices(C):
 
 @pytest.mark.other
 @pytest.mark.info
+def test_connect_with_path(C):
+    ids = gs(C.NK_list_devices_by_cpuID())
+    # NK_list_devices_by_cpuID already opened the devices, so we have to close
+    # them before trying to reconnect
+    assert C.NK_logout() == 0
+
+    devices_list = ids.split(b';')
+    for value in devices_list:
+        parts = value.split(b'_p_')
+        assert len(parts) < 3
+        if len(parts) == 2:
+            path = parts[1]
+        else:
+            path = parts[0]
+        assert C.NK_connect_with_path(path) == 1
+
+
+@pytest.mark.other
+@pytest.mark.info
 def test_get_status_storage_multiple(C):
     ids = gs(C.NK_list_devices_by_cpuID())
     print(ids)

--- a/unittest/test_multiple_devices.cc
+++ b/unittest/test_multiple_devices.cc
@@ -35,9 +35,11 @@ using namespace nitrokey;
 
 TEST_CASE("List devices", "[BASIC]") {
     shared_ptr<Stick20> d = make_shared<Stick20>();
-    auto v = d->enumerate();
+    auto v = Device::enumerate();
     REQUIRE(v.size() > 0);
     for (auto i : v){
+        if (i.m_deviceModel != DeviceModel::STORAGE)
+            continue;
         auto a = i.m_path;
         std::cout << a;
         d->set_path(a);
@@ -54,11 +56,13 @@ TEST_CASE("List devices", "[BASIC]") {
 
 TEST_CASE("Regenerate AES keys", "[BASIC]") {
     shared_ptr<Stick20> d = make_shared<Stick20>();
-    auto v = d->enumerate();
+    auto v = Device::enumerate();
     REQUIRE(v.size() > 0);
 
     std::vector<shared_ptr<Stick20>> devices;
     for (auto i : v){
+        if (i.m_deviceModel != DeviceModel::STORAGE)
+            continue;
         auto a = i.m_path;
         std::cout << a << endl;
         d = make_shared<Stick20>();

--- a/unittest/test_multiple_devices.cc
+++ b/unittest/test_multiple_devices.cc
@@ -37,7 +37,8 @@ TEST_CASE("List devices", "[BASIC]") {
     shared_ptr<Stick20> d = make_shared<Stick20>();
     auto v = d->enumerate();
     REQUIRE(v.size() > 0);
-    for (auto a : v){
+    for (auto i : v){
+        auto a = i.m_path;
         std::cout << a;
         d->set_path(a);
         d->connect();
@@ -57,7 +58,8 @@ TEST_CASE("Regenerate AES keys", "[BASIC]") {
     REQUIRE(v.size() > 0);
 
     std::vector<shared_ptr<Stick20>> devices;
-    for (auto a : v){
+    for (auto i : v){
+        auto a = i.m_path;
         std::cout << a << endl;
         d = make_shared<Stick20>();
         d->set_path(a);

--- a/unittest/test_multiple_devices.cc
+++ b/unittest/test_multiple_devices.cc
@@ -90,7 +90,10 @@ TEST_CASE("Use API", "[BASIC]") {
     REQUIRE(v.size() > 0);
 
     for (int i=0; i<10; i++){
-        for (auto a : v) {
+        for (auto i : v) {
+            if (i.m_deviceModel != DeviceModel::STORAGE)
+                continue;
+            auto a = i.m_path;
             std::cout <<"Connect with: " << a <<
             " " << std::boolalpha << nm->connect_with_path(a) << " ";
             try{

--- a/unittest/test_multiple_devices.cc
+++ b/unittest/test_multiple_devices.cc
@@ -42,9 +42,8 @@ TEST_CASE("List devices", "[BASIC]") {
             std::cout << "Could not create device with model " << i.m_deviceModel << "\n";
             continue;
         }
-        std::cout << i.m_deviceModel << " " << i.m_path << " ";
-        std::wcout << i.m_serialNumber;
-        std::cout << " |";
+        std::cout << i.m_deviceModel << " " << i.m_path << " "
+          << i.m_serialNumber << " |";
         d->set_path(i.m_path);
         d->connect();
         auto res = GetStatus::CommandTransaction::run(d);
@@ -116,9 +115,8 @@ TEST_CASE("Use API", "[BASIC]") {
     REQUIRE(v.size() > 0);
 
     for (auto i : v) {
-      std::cout << "Connect with: " << i.m_deviceModel << " " << i.m_path << " ";
-      std::wcout << i.m_serialNumber;
-      std::cout << " | " << std::boolalpha << nm->connect_with_path(i.m_path) << " |";
+      std::cout << "Connect with: " << i.m_deviceModel << " " << i.m_path << " "
+        << i.m_serialNumber << " | " << std::boolalpha << nm->connect_with_path(i.m_path) << " |";
       try {
         auto status = nm->get_status();
         std::cout << " " << status.card_serial_u32 << " "

--- a/unittest/test_multiple_devices.cc
+++ b/unittest/test_multiple_devices.cc
@@ -115,6 +115,29 @@ TEST_CASE("Use API", "[BASIC]") {
     auto v = nm->list_devices();
     REQUIRE(v.size() > 0);
 
+    for (auto i : v) {
+      std::cout << "Connect with: " << i.m_deviceModel << " " << i.m_path << " ";
+      std::wcout << i.m_serialNumber;
+      std::cout << " | " << std::boolalpha << nm->connect_with_path(i.m_path) << " |";
+      try {
+        auto status = nm->get_status();
+        std::cout << " " << status.card_serial_u32 << " "
+                  << status.get_card_serial_hex()
+                  << std::endl;
+      } catch (const LongOperationInProgressException &e) {
+        std::cout << "long operation in progress on " << i.m_path
+          << " " << std::to_string(e.progress_bar_value) << std::endl;
+      }
+    }
+}
+
+
+TEST_CASE("Use Storage API", "[BASIC]") {
+    auto nm = NitrokeyManager::instance();
+    nm->set_loglevel(2);
+    auto v = nm->list_devices();
+    REQUIRE(v.size() > 0);
+
     for (int i=0; i<10; i++){
         for (auto i : v) {
             if (i.m_deviceModel != DeviceModel::STORAGE)

--- a/unittest/test_multiple_devices.cc
+++ b/unittest/test_multiple_devices.cc
@@ -29,6 +29,7 @@ const char * RFC_SECRET = "12345678901234567890";
 #include <iostream>
 #include <NitrokeyManager.h>
 #include <stick20_commands.h>
+#include "../NK_C_API.h"
 
 using namespace nitrokey;
 
@@ -105,6 +106,24 @@ TEST_CASE("Regenerate AES keys", "[BASIC]") {
         //TODO watch out for multiple hid_exit calls
         d->disconnect();
     }
+}
+
+
+TEST_CASE("Use C API", "[BASIC]") {
+    auto ptr = NK_list_devices();
+    auto first_ptr = ptr;
+    REQUIRE(ptr != nullptr);
+
+    while (ptr) {
+      std::cout << "Connect with: " << ptr->model << " " << ptr->path << " "
+        << ptr->serial_number << " | " << NK_connect_with_path(ptr->path) << " | ";
+      auto status = NK_status();
+      std::cout << status << std::endl;
+      free(status);
+      ptr = ptr->next;
+    }
+
+    NK_free_device_info(first_ptr);
 }
 
 

--- a/unittest/test_multiple_devices.cc
+++ b/unittest/test_multiple_devices.cc
@@ -34,6 +34,28 @@ using namespace nitrokey;
 
 
 TEST_CASE("List devices", "[BASIC]") {
+    auto v = Device::enumerate();
+    REQUIRE(v.size() > 0);
+    for (auto i : v){
+        auto d = Device::create(i.m_deviceModel);
+        if (!d) {
+            std::cout << "Could not create device with model " << i.m_deviceModel << "\n";
+            continue;
+        }
+        std::cout << i.m_deviceModel << " " << i.m_path << " ";
+        std::wcout << i.m_serialNumber;
+        std::cout << " |";
+        d->set_path(i.m_path);
+        d->connect();
+        auto res = GetStatus::CommandTransaction::run(d);
+        std::cout << " " << res.data().card_serial_u32 << " "
+                  << res.data().get_card_serial_hex()
+                  << std::endl;
+        d->disconnect();
+    }
+}
+
+TEST_CASE("List Storage devices", "[BASIC]") {
     shared_ptr<Stick20> d = make_shared<Stick20>();
     auto v = Device::enumerate();
     REQUIRE(v.size() > 0);


### PR DESCRIPTION
This patch series introduces these changes to the public API:
- `NitrokeyManager::list_devices()` returns a vector of `DeviceInfo` instead of strings.
- `NitrokeyManager::list_devices()` also returns Pro devices.
- `NitrokeyManager::connect_with_path(std::string)` also works for Pro devices.
- `NK_list_devices` and `NK_connect_with_path` are added to the C API.  `NK_list_devices` returns a list of `NK_device_info` structs that can be freed with the `NK_free_device_info` function.
----
I know this is a rather large pull request, but I think it is one logical group.  I tried to make the commits minimal to make it easier to review the changes.