### PR TITLE
Add tqdm to unittest/requirements.txt

### DIFF
--- a/unittest/requirements.txt
+++ b/unittest/requirements.txt
@@ -1,4 +1,5 @@
 cffi
 pytest-repeat
 pytest-randomly
+tqdm
 oath


### PR DESCRIPTION
The test_mulitple.py unit test requires tqdm, which is not a dependency
of any of the requirements and was not included in the requirements
list.