### PR TITLE
Return -2 if an error occured in NK_get_progress_bar_value

### DIFF
--- a/NK_C_API.cc
+++ b/NK_C_API.cc
@@ -697,9 +697,9 @@ NK_C_API char* NK_get_SD_usage_data_as_string() {
 
 	NK_C_API int NK_get_progress_bar_value() {
 		auto m = NitrokeyManager::instance();
-		return get_with_result([&]() {
+		return std::get<1>(get_with_status([&]() {
 			return m->get_progress_bar_value();
-		});
+		}, -2));
 	}
 
 	NK_C_API int NK_get_major_firmware_version() {

--- a/NK_C_API.h
+++ b/NK_C_API.h
@@ -747,7 +747,8 @@ extern "C" {
 	/**
 	 * Get progress value of current long operation.
 	 * Storage only
-	 * @return int in range 0-100 or -1 if device is not busy
+	 * @return int in range 0-100 or -1 if device is not busy or -2 if an
+	 *         error occured
 	 */
 	NK_C_API int NK_get_progress_bar_value();
 


### PR DESCRIPTION
NK_get_progress_bar_value returns the progress value from 0 to 100 or -1
if there is no pending operation.  In the previous implementation, it
also returned zero if an error occurred, making it impossible to
distinguish progress zero and an error.  Therefore, we change the return
value to -2 if an error occured.