### PR TITLE
Add NK_get_SD_usage_data function to C API

### DIFF
--- a/NK_C_API.cc
+++ b/NK_C_API.cc
@@ -687,6 +687,23 @@ extern "C" {
 		return 0;
   }
 
+	NK_C_API int NK_get_SD_usage_data(struct NK_SD_usage_data* out) {
+		if (out == nullptr)
+			return -1;
+		auto m = NitrokeyManager::instance();
+		auto result = get_with_status([&]() {
+			return m->get_SD_usage_data();
+		}, std::make_pair<uint8_t, uint8_t>(0, 0));
+		auto error_code = std::get<0>(result);
+		if (error_code != 0)
+			return error_code;
+
+		auto data = std::get<1>(result);
+		out->write_level_min = std::get<0>(data);
+		out->write_level_max = std::get<1>(data);
+
+		return 0;
+	}
 
 NK_C_API char* NK_get_SD_usage_data_as_string() {
 		auto m = NitrokeyManager::instance();

--- a/NK_C_API.h
+++ b/NK_C_API.h
@@ -128,6 +128,23 @@ extern "C" {
 		bool stick_initialized;
         };
 
+	/**
+	 * Data about the usage of the SD card.
+	 */
+	struct NK_SD_usage_data {
+		/**
+		 * The minimum write level, as a percentage of the total card
+		 * size.
+		 */
+		uint8_t write_level_min;
+		/**
+		 * The maximum write level, as a percentage of the total card
+		 * size.
+		 */
+		uint8_t write_level_max;
+	};
+
+
    struct NK_storage_ProductionTest{
     uint8_t FirmwareVersion_au8[2];
     uint8_t FirmwareVersionInternal_u8;
@@ -735,6 +752,17 @@ extern "C" {
 	 * @return command processing error code
 	 */
 	NK_C_API int NK_get_status_storage(struct NK_storage_status* out);
+
+	/**
+	 * Get SD card usage attributes. Usable during hidden volumes creation.
+	 * If the command was successful (return value 0), the usage data is
+	 * written to the output pointer’s target.  The output pointer must
+	 * not be null.
+	 * Storage only
+	 * @param out the output pointer for the usage data
+	 * @return command processing error code
+	 */
+	NK_C_API int NK_get_SD_usage_data(struct NK_SD_usage_data* out);
 
 	/**
 	 * Get SD card usage attributes as string.


### PR DESCRIPTION
The NK_get_SD_usage_data function returns the minimum and maximum write
level for the SD card.  This function cannot be tested due to the
missing struct support in the Python tests.
