### PR TITLE
Return firmware version parts as uint8_t instead of int

### DIFF
--- a/NK_C_API.cc
+++ b/NK_C_API.cc
@@ -719,14 +719,14 @@ NK_C_API char* NK_get_SD_usage_data_as_string() {
 		}, -2));
 	}
 
-	NK_C_API int NK_get_major_firmware_version() {
+	NK_C_API uint8_t NK_get_major_firmware_version() {
 		auto m = NitrokeyManager::instance();
 		return get_with_result([&]() {
 			return m->get_major_firmware_version();
 		});
 	}
 
-  NK_C_API int NK_get_minor_firmware_version() {
+  NK_C_API uint8_t NK_get_minor_firmware_version() {
 		auto m = NitrokeyManager::instance();
 		return get_with_result([&]() {
 			return m->get_minor_firmware_version();

--- a/NK_C_API.h
+++ b/NK_C_API.h
@@ -568,13 +568,13 @@ extern "C" {
 	 * Get device's major firmware version
 	 * @return major part of the version number (e.g. 0 from 0.48, 0 from 0.7 etc.)
 	 */
-	NK_C_API int NK_get_major_firmware_version();
+	NK_C_API uint8_t NK_get_major_firmware_version();
 
 	/**
 	 * Get device's minor firmware version
 	 * @return minor part of the version number (e.g. 7 from 0.7, 48 from 0.48 etc.)
 	 */
-	NK_C_API int NK_get_minor_firmware_version();
+	NK_C_API uint8_t NK_get_minor_firmware_version();
 
   /**
    * Function to determine unencrypted volume PIN type

--- a/NitrokeyManager.cc
+++ b/NitrokeyManager.cc
@@ -937,7 +937,7 @@ using nitrokey::misc::strcpyT;
       return false;
     }
 
-    int NitrokeyManager::get_minor_firmware_version(){
+    uint8_t NitrokeyManager::get_minor_firmware_version(){
       switch(device->get_device_model()){
         case DeviceModel::PRO:{
           auto status_p = GetStatus::CommandTransaction::run(device);
@@ -953,7 +953,7 @@ using nitrokey::misc::strcpyT;
       }
       return 0;
     }
-    int NitrokeyManager::get_major_firmware_version(){
+    uint8_t NitrokeyManager::get_major_firmware_version(){
       switch(device->get_device_model()){
         case DeviceModel::PRO:{
           auto status_p = GetStatus::CommandTransaction::run(device);

--- a/libnitrokey/NitrokeyManager.h
+++ b/libnitrokey/NitrokeyManager.h
@@ -215,7 +215,7 @@ char * strndup(const char* str, size_t maxlen);
 
       template <typename S, typename A, typename T>
         void authorize_packet(T &package, const char *admin_temporary_password, shared_ptr<Device> device);
-        int get_minor_firmware_version();
+        uint8_t get_minor_firmware_version();
 
         explicit NitrokeyManager();
         void set_log_function(std::function<void(std::string)> log_function);
@@ -278,7 +278,7 @@ char * strndup(const char* str, size_t maxlen);
        */
       void set_encrypted_volume_read_write(const char *admin_pin);
 
-      int get_major_firmware_version();
+      uint8_t get_major_firmware_version();
 
       bool is_smartcard_in_use();
 


### PR DESCRIPTION
The firmware version parts returned by the Nitrokey devices are uint8_t
values.  This is part of the public API as part of the NK_storage_status
struct.  For consistency with this API, this patch changes the functions
NK_get_major_firmware_version and NK_get_minor_firmware_version to
return uint8_t instead of int.