### PR TITLE
Export PWS slot count in C API

### DIFF
--- a/NK_C_API.cc
+++ b/NK_C_API.cc
@@ -27,6 +27,7 @@
 #include "libnitrokey/LibraryException.h"
 #include "libnitrokey/cxx_semantics.h"
 #include "libnitrokey/stick20_commands.h"
+#include "libnitrokey/device_proto.h"
 #include "version.h"
 
 #ifdef _MSC_VER
@@ -44,6 +45,7 @@ char * strndup(const char* str, size_t maxlen) {
 
 using namespace nitrokey;
 
+const uint8_t NK_PWS_SLOT_COUNT = PWS_SLOT_COUNT;
 static uint8_t NK_last_command_status = 0;
 static const int max_string_field_length = 100;
 

--- a/NK_C_API.h
+++ b/NK_C_API.h
@@ -37,6 +37,11 @@
 extern "C" {
 #endif
 
+  /**
+   * The number of slots in the password safe.
+   */
+  extern const uint8_t NK_PWS_SLOT_COUNT;
+
   static const int MAXIMUM_STR_REPLY_LENGTH = 8192;
 
         /**


### PR DESCRIPTION
The C++ API already defines the number of slots in device_proto.h.  This
patch adds it to the C API.  It is especially important to have this
constant in the C API as it is the length of the array returned by
NK_get_password_safe_slot_status.