### PR TITLE
Fix regex in unittest for pre-releases and git checkouts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ execute_process(
 )
 ENDIF()
 IF((NOT ${ADD_GIT_INFO}) OR (${PROJECT_VERSION_GIT_RETURN_CODE}))
-	SET(PROJECT_VERSION_GIT "unknown")
+	SET(PROJECT_VERSION_GIT "v${PROJECT_VERSION}")
 ENDIF()
 MESSAGE(STATUS "Setting Git library version to: " ${PROJECT_VERSION_GIT} )
 configure_file("version.cc.in" "version.cc" @ONLY)

--- a/unittest/test_offline.cc
+++ b/unittest/test_offline.cc
@@ -178,8 +178,8 @@ TEST_CASE("Test version getter", "[fast]") {
   // Optional <patch> field is allowed as well.
   INFO("This test will fail, if the full git commit version was not collected during library build.");
   std::string s = library_version;
-  std::string version("v[0-9]+\\.[0-9]+(\\.[0-9]+)?");
-  std::string git_suffix("-[0-9]+-g[0-9a-z]+");
+  std::string version("(pre-)?v[0-9]+\\.[0-9]+(\\.[0-9]+)?");
+  std::string git_suffix("(-[0-9]+)+-g[0-9a-z]+");
   std::regex pattern(version + "(" + git_suffix + ")?");
   REQUIRE(std::regex_match(s, pattern));
 }


### PR DESCRIPTION
Hi @szszszsz 
The version test is very sensitive to the actual string, and causes failures in the git, but also versioned release ebuilds in Gentoo. I fixed it for building from `git`, but also when using from a git archive tarball.

In general I would suggest using more decoupled versioning, i.e., create the Main version string from MAJOR.MINOR.PATCH, and append the (possibly dirty) commit id to that, as an optional suffix. That is more robust and requires less dependence on the output of `git describe`. For instance, this is how Autoconf and the gnulib git module do it, and the version string is more stable and less wonky.