### PR TITLE
Increase user password buffer in IsAESSupported command

### DIFF
--- a/libnitrokey/stick10_commands.h
+++ b/libnitrokey/stick10_commands.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018 Nitrokey UG
+ * Copyright (c) 2015-2019 Nitrokey UG
  *
  * This file is part of libnitrokey.
  *
@@ -815,7 +815,7 @@ class ChangeUserPin : Command<CommandID::CHANGE_USER_PIN> {
 class IsAESSupported : Command<CommandID::DETECT_SC_AES> {
  public:
   struct CommandPayload {
-    uint8_t user_password[20];
+    uint8_t user_password[30];
       std::string dissect() const {
         std::stringstream ss;
         print_to_ss_volatile(user_password);


### PR DESCRIPTION
The IsAESSupported command struct has a 20 byte buffer size for storing
the user password. That is in contrast to, say, the EnablePasswordSafe
struct which uses a 30 byte buffer. Such a smaller buffer can cause
string length errors to be emitted for a legitimate user PIN as has been
found as part of the investigation for d-e-s-o/nitrocli#85. That is, the
nitrokey allows for setting a user PIN of 21 characters. Retrieving an
OTP using such a PIN works fine, whereas inquiring the PWS status does
not, as it first tries to cram the supplied password into 20 characters,
which fails.
This change increases the buffer size in the IsAESSupported command
struct to 30 bytes.