### PR TITLE
Make `PROJECT_VERSION_GIT` fallback more robust

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,14 @@ execute_process(
 	ERROR_QUIET
 )
 ENDIF()
-IF((NOT ${ADD_GIT_INFO}) OR (${PROJECT_VERSION_GIT_RETURN_CODE}))
+# the version.h generation logic is tricky in a number of ways:
+# 1. git describe on a release tarball will always fail with
+#    a non-zero return code, usually 128
+# 2. If git is not installed, PROJECT_VERSION_GIT_RETURN_CODE
+#    will contain the string 'No such file or directory'
+# Hence fallback to PROJECT_VERSION when the return code is NOT 0.
+IF((NOT ${ADD_GIT_INFO}) OR (NOT ${PROJECT_VERSION_GIT_RETURN_CODE} STREQUAL "0"))
+	MESSAGE(STATUS "Setting fallback Git library version")
 	SET(PROJECT_VERSION_GIT "v${PROJECT_VERSION}")
 ENDIF()
 MESSAGE(STATUS "Setting Git library version to: " ${PROJECT_VERSION_GIT} )


### PR DESCRIPTION
* The previous check for `PROJECT_VERSION_GIT_RETURN_CODE`
  was fragile and did not check specifically that the
  return code is *exactly* 0.

@szszszsz This fixes `PROJECT_VERSION_GIT` being empty if git was not installed. See also: https://bugs.gentoo.org/689614