### PR TITLE
Fix get_status for Nitrokey Storage

### DIFF
--- a/NitrokeyManager.cc
+++ b/NitrokeyManager.cc
@@ -401,7 +401,19 @@ using nitrokey::misc::strcpyT;
     stick10::GetStatus::ResponsePayload NitrokeyManager::get_status(){
       try{
         auto response = GetStatus::CommandTransaction::run(device);
-        return response.data();
+        auto data = response.data();
+        if (device != nullptr && device->get_device_model() == DeviceModel::STORAGE) {
+          // The GET_STATUS command does not work for the Nitrokey Storage,
+          // see https://github.com/Nitrokey/nitrokey-storage-firmware/issues/96
+          // Therefore, we have to use the GET_DEVICE_STATUS command to query
+          // the correct serial number and firmware version.
+          auto response2 = stick20::GetDeviceStatus::CommandTransaction::run(device);
+          auto data2 = response2.data();
+          data.firmware_version_st.major = data2.versionInfo.major;
+          data.firmware_version_st.minor = data2.versionInfo.minor;
+          data.card_serial_u32 = data2.ActiveSmartCardID_u32;
+        }
+        return data;
       }
       catch (DeviceSendingFailure &e){
 //        disconnect();

--- a/unittest/test_pro.py
+++ b/unittest/test_pro.py
@@ -723,8 +723,27 @@ def test_get_status(C):
         raise Exception("Could not allocate status")
     err = C.NK_get_status(status_st)
     assert err == 0
+
+    # check firmware version
+    firmware_version_major = C.NK_get_major_firmware_version()
+    firmware_version_minor = C.NK_get_minor_firmware_version()
+
     assert status_st.firmware_version_major == 0
     assert status_st.firmware_version_minor != 0
+    assert status_st.firmware_version_major == firmware_version_major
+    assert status_st.firmware_version_minor == firmware_version_minor
+
+    # check serial number
+    serial_number = gs(C.NK_device_serial_number())
+    assert status_st.serial_number_smart_card != 0
+    assert '{:08x}'.format(status_st.serial_number_smart_card) == serial_number.decode('ascii')
+
+    # check config
+    config = C.NK_read_config()
+    assert status_st.config_numlock == config[0]
+    assert status_st.config_capslock == config[1]
+    assert status_st.config_scrolllock == config[2]
+    assert status_st.otp_user_password == config[3]
 
 
 @pytest.mark.status


### PR DESCRIPTION
Extends the test_get_status test case to catch the problem with get_status for
the Nitrokey Storage described in #166, and then fixes the problem by adding
the GET_DEVICE_STATUS command to the NitrokeyManager::get_status method.