### PR TITLE
Return serial number as uint32_t

### DIFF
--- a/NK_C_API.cc
+++ b/NK_C_API.cc
@@ -299,6 +299,13 @@ extern "C" {
 		});
 	}
 
+	NK_C_API uint32_t NK_device_serial_number_as_u32() {
+		auto m = NitrokeyManager::instance();
+		return get_with_result([&]() {
+                        return m->get_serial_number_as_u32();
+		});
+	}
+
 	NK_C_API char * NK_get_hotp_code(uint8_t slot_number) {
 		return NK_get_hotp_code_PIN(slot_number, "");
 	}

--- a/NK_C_API.h
+++ b/NK_C_API.h
@@ -386,6 +386,14 @@ extern "C" {
 	NK_C_API char * NK_device_serial_number();
 
 	/**
+	 * Return the device's serial number string as an integer.  Use
+         * NK_last_command_status to check for an error if this function
+         * returns zero.
+	 * @return device's serial number as an integer
+	 */
+	NK_C_API uint32_t NK_device_serial_number_as_u32();
+
+	/**
 	 * Get last command processing status. Useful for commands which returns the results of their own and could not return
 	 * an error code.
 	 * @return previous command processing error code

--- a/NitrokeyManager.cc
+++ b/NitrokeyManager.cc
@@ -380,22 +380,16 @@ using nitrokey::misc::strcpyT;
 
 
     string NitrokeyManager::get_serial_number() {
-        if (device == nullptr) { return ""; };
-      switch (device->get_device_model()) {
-        case DeviceModel::PRO: {
-          auto response = GetStatus::CommandTransaction::run(device);
-          return nitrokey::misc::toHex(response.data().card_serial_u32);
+      try {
+        auto serial_number = this->get_serial_number_as_u32();
+        if (serial_number == 0) {
+          return "NA";
+        } else {
+          return nitrokey::misc::toHex(serial_number);
         }
-          break;
-
-        case DeviceModel::STORAGE:
-        {
-          auto response = stick20::GetDeviceStatus::CommandTransaction::run(device);
-          return nitrokey::misc::toHex(response.data().ActiveSmartCardID_u32);
-        }
-          break;
+      } catch (DeviceNotConnected& e) {
+        return "";
       }
-      return "NA";
     }
 
     uint32_t NitrokeyManager::get_serial_number_as_u32() {

--- a/NitrokeyManager.cc
+++ b/NitrokeyManager.cc
@@ -398,6 +398,25 @@ using nitrokey::misc::strcpyT;
       return "NA";
     }
 
+    uint32_t NitrokeyManager::get_serial_number_as_u32() {
+        if (device == nullptr) { throw DeviceNotConnected("device not connected"); }
+      switch (device->get_device_model()) {
+        case DeviceModel::PRO: {
+          auto response = GetStatus::CommandTransaction::run(device);
+          return response.data().card_serial_u32;
+        }
+          break;
+
+        case DeviceModel::STORAGE:
+        {
+          auto response = stick20::GetDeviceStatus::CommandTransaction::run(device);
+          return response.data().ActiveSmartCardID_u32;
+        }
+          break;
+      }
+      return 0;
+    }
+
     stick10::GetStatus::ResponsePayload NitrokeyManager::get_status(){
       try{
         auto response = GetStatus::CommandTransaction::run(device);

--- a/libnitrokey/NitrokeyManager.h
+++ b/libnitrokey/NitrokeyManager.h
@@ -104,6 +104,7 @@ char * strndup(const char* str, size_t maxlen);
         stick10::GetStatus::ResponsePayload get_status();
         string get_status_as_string();
         string get_serial_number();
+        uint32_t get_serial_number_as_u32();
 
         char * get_totp_slot_name(uint8_t slot_number);
         char * get_hotp_slot_name(uint8_t slot_number);

--- a/unittest/test_offline.cc
+++ b/unittest/test_offline.cc
@@ -67,6 +67,10 @@ TEST_CASE("Test C++ side behaviour in offline", "[fast]") {
   REQUIRE(serial_number.empty());
 
   REQUIRE_THROWS_AS(
+    i->get_serial_number_as_u32(), DeviceNotConnected
+  );
+
+  REQUIRE_THROWS_AS(
     i->get_status(), DeviceNotConnected
   );
 

--- a/unittest/test_pro.py
+++ b/unittest/test_pro.py
@@ -704,6 +704,13 @@ def test_get_serial_number(C):
     print(('Serial number of the device: ', sn))
 
 
+@pytest.mark.status
+def test_get_serial_number_as_u32(C):
+    sn = C.NK_device_serial_number_as_u32()
+    assert sn > 0
+    print(('Serial number of the device (u32): ', sn))
+
+
 @pytest.mark.otp
 @pytest.mark.parametrize("secret", ['000001', '00'*10+'ff', '00'*19+'ff', '000102',
                                     '00'*29+'ff', '00'*39+'ff', '002EF43F51AFA97BA2B46418768123C9E1809A5B' ])


### PR DESCRIPTION
This patch series adds functions to the C++ and C API that also return the
serial number as an integer (instead of only returning a formatted hex string).

Fixes #172.