### PR TITLE
Refactor LongOperationInProgressException

### DIFF
--- a/libnitrokey/DeviceCommunicationExceptions.h
+++ b/libnitrokey/DeviceCommunicationExceptions.h
@@ -69,5 +69,6 @@ public:
   uint8_t getType() const {return 5;};
 };
 
+// LongOperationInProgressException with type 6, see LongOperationInProgressException.h
 
 #endif //LIBNITROKEY_DEVICECOMMUNICATIONEXCEPTIONS_H

--- a/libnitrokey/LongOperationInProgressException.h
+++ b/libnitrokey/LongOperationInProgressException.h
@@ -22,23 +22,22 @@
 #ifndef LIBNITROKEY_LONGOPERATIONINPROGRESSEXCEPTION_H
 #define LIBNITROKEY_LONGOPERATIONINPROGRESSEXCEPTION_H
 
-#include "CommandFailedException.h"
+#include "DeviceCommunicationExceptions.h"
 
-class LongOperationInProgressException : public CommandFailedException {
+class LongOperationInProgressException : public DeviceCommunicationException {
 
 public:
     unsigned char progress_bar_value;
 
-    LongOperationInProgressException(
-        unsigned char _command_id, uint8_t last_command_status, unsigned char _progress_bar_value)
-    : CommandFailedException(_command_id, last_command_status), progress_bar_value(_progress_bar_value){
+    LongOperationInProgressException(unsigned char _progress_bar_value)
+    : DeviceCommunicationException("Device returned busy status with long operation in progress"),
+      progress_bar_value(_progress_bar_value){
       LOG(
           std::string("LongOperationInProgressException, progress bar status: ")+
               std::to_string(progress_bar_value), nitrokey::log::Loglevel::DEBUG);
     }
-    virtual const char *what() const throw() {
-      return "Device returned busy status with long operation in progress";
-    }
+
+    uint8_t getType() const {return 6;};
 };
 
 

--- a/libnitrokey/device_proto.h
+++ b/libnitrokey/device_proto.h
@@ -439,8 +439,7 @@ namespace nitrokey {
                   == stick20::device_status::busy_progressbar){
                 dev->m_counters.busy_progressbar++;
                 LOG(std::string("Throw: Long operation in progress exception"), Loglevel::DEBUG_L1);
-                throw LongOperationInProgressException(
-                    resp.command_id, resp.device_status, resp.storage_status.progress_bar_value);
+                throw LongOperationInProgressException(resp.storage_status.progress_bar_value);
               }
 
               if (!resp.isValid()) {


### PR DESCRIPTION
This patch changes LongOperationInProgressException to derive from
DeviceCommunicationException.  This makes it easier to use the C API as
the exception now has a unique numerical identifier.

Fixes #170.