### PR TITLE
Deprecate old setters for UV ro/rw attribute

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: generic
-sudo: false
 os: osx
 env:
   global:
     - CF="-DCOMPILE_OFFLINE_TESTS=1 -DERROR_ON_WARNING=ON"
 
-matrix:
+jobs:
   include:
     - osx_image: xcode11.5
     - osx_image: xcode9.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ set_target_properties(nitrokey PROPERTIES
 
 OPTION(ERROR_ON_WARNING "Stop compilation on warning found (not supported for MSVC)" OFF)
 if (NOT MSVC)
-    set(COMPILE_FLAGS "-Wall -Wno-unused-function -Wcast-qual -Woverloaded-virtual -Wsign-compare -Wformat -Wformat-security")
+    set(COMPILE_FLAGS "-Wall -Wno-unused-function -Wcast-qual -Woverloaded-virtual -Wsign-compare -Wformat -Wformat-security -Wno-deprecated")
     IF(NOT APPLE)
         if (ERROR_ON_WARNING)
             set(COMPILE_FLAGS "${COMPILE_FLAGS} -Werror")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ set_target_properties(nitrokey PROPERTIES
 
 OPTION(ERROR_ON_WARNING "Stop compilation on warning found (not supported for MSVC)" OFF)
 if (NOT MSVC)
-    set(COMPILE_FLAGS "-Wall -Wno-unused-function -Wcast-qual -Woverloaded-virtual -Wsign-compare -Wformat -Wformat-security -Wno-deprecated")
+    set(COMPILE_FLAGS "-Wall -Wno-unused-function -Wcast-qual -Woverloaded-virtual -Wsign-compare -Wformat -Wformat-security")
     IF(NOT APPLE)
         if (ERROR_ON_WARNING)
             set(COMPILE_FLAGS "${COMPILE_FLAGS} -Werror")

--- a/NK_C_API.cc
+++ b/NK_C_API.cc
@@ -604,6 +604,7 @@ extern "C" {
 		});
 	}
 
+  // deprecated, noop on v0.51 and older (excl. v0.49)
 	NK_C_API int NK_set_unencrypted_read_only(const char *user_pin) {
 		auto m = NitrokeyManager::instance();
 		return get_without_result([&]() {
@@ -611,7 +612,8 @@ extern "C" {
 		});
 	}
 
-	NK_C_API int NK_set_unencrypted_read_write(const char *user_pin) {
+	// deprecated, noop on v0.51 and older (excl. v0.49)
+  NK_C_API int NK_set_unencrypted_read_write(const char *user_pin) {
 		auto m = NitrokeyManager::instance();
 		return get_without_result([&]() {
 			m->set_unencrypted_read_write(user_pin);

--- a/NK_C_API.cc
+++ b/NK_C_API.cc
@@ -605,6 +605,8 @@ extern "C" {
 	}
 
   // deprecated, noop on v0.51 and older (excl. v0.49)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	NK_C_API int NK_set_unencrypted_read_only(const char *user_pin) {
 		auto m = NitrokeyManager::instance();
 		return get_without_result([&]() {
@@ -619,6 +621,7 @@ extern "C" {
 			m->set_unencrypted_read_write(user_pin);
 		});
 	}
+#pragma GCC diagnostic pop
 
 	NK_C_API int NK_set_unencrypted_read_only_admin(const char *admin_pin) {
 		auto m = NitrokeyManager::instance();

--- a/NK_C_API.h
+++ b/NK_C_API.h
@@ -837,7 +837,8 @@ extern "C" {
 	 * @param user_pin 20 characters User PIN
 	 * @return command processing error code
 	 */
-	NK_C_API int NK_set_unencrypted_read_only(const char *user_pin);
+  [[deprecated("NK_set_unencrypted_read_only is deprecated. Use NK_set_unencrypted_read_only_admin instead")]]
+  NK_C_API int NK_set_unencrypted_read_only(const char *user_pin);
 
 	/**
 	 * Make unencrypted volume read-write.
@@ -849,7 +850,8 @@ extern "C" {
 	 * @param user_pin 20 characters User PIN
 	 * @return command processing error code
 	 */
-	NK_C_API int NK_set_unencrypted_read_write(const char *user_pin);
+  [[deprecated("NK_set_unencrypted_read_write is deprecated. Use NK_set_unencrypted_read_write_admin instead")]]
+  NK_C_API int NK_set_unencrypted_read_write(const char *user_pin);
 
 	/**
 	 * Make unencrypted volume read-only.

--- a/NK_C_API.h
+++ b/NK_C_API.h
@@ -837,7 +837,8 @@ extern "C" {
 	 * @param user_pin 20 characters User PIN
 	 * @return command processing error code
 	 */
-  [[deprecated("NK_set_unencrypted_read_only is deprecated. Use NK_set_unencrypted_read_only_admin instead")]]
+  //[[deprecated("NK_set_unencrypted_read_only is deprecated. Use NK_set_unencrypted_read_only_admin instead")]]
+  DEPRECATED
   NK_C_API int NK_set_unencrypted_read_only(const char *user_pin);
 
 	/**
@@ -850,7 +851,8 @@ extern "C" {
 	 * @param user_pin 20 characters User PIN
 	 * @return command processing error code
 	 */
-  [[deprecated("NK_set_unencrypted_read_write is deprecated. Use NK_set_unencrypted_read_write_admin instead")]]
+  //[[deprecated("NK_set_unencrypted_read_write is deprecated. Use NK_set_unencrypted_read_write_admin instead")]]
+  DEPRECATED
   NK_C_API int NK_set_unencrypted_read_write(const char *user_pin);
 
 	/**

--- a/NK_C_API.h
+++ b/NK_C_API.h
@@ -837,7 +837,7 @@ extern "C" {
 	 * @param user_pin 20 characters User PIN
 	 * @return command processing error code
 	 */
-  //[[deprecated("NK_set_unencrypted_read_only is deprecated. Use NK_set_unencrypted_read_only_admin instead")]]
+  //[[deprecated("Use NK_set_unencrypted_read_only_admin instead")]]
   DEPRECATED
   NK_C_API int NK_set_unencrypted_read_only(const char *user_pin);
 
@@ -851,7 +851,7 @@ extern "C" {
 	 * @param user_pin 20 characters User PIN
 	 * @return command processing error code
 	 */
-  //[[deprecated("NK_set_unencrypted_read_write is deprecated. Use NK_set_unencrypted_read_write_admin instead")]]
+  //[[deprecated("Use NK_set_unencrypted_read_write_admin instead")]]
   DEPRECATED
   NK_C_API int NK_set_unencrypted_read_write(const char *user_pin);
 

--- a/libnitrokey/NitrokeyManager.h
+++ b/libnitrokey/NitrokeyManager.h
@@ -158,6 +158,7 @@ char * strndup(const char* str, size_t maxlen);
          * Does nothing otherwise.
          * @param user_pin User PIN
          */
+        [[deprecated("set_unencrypted_read_only is deprecated. Use set_unencrypted_read_only_admin instead.")]]
         void set_unencrypted_read_only(const char *user_pin);
 
         /**
@@ -174,6 +175,7 @@ char * strndup(const char* str, size_t maxlen);
          * Does nothing otherwise.
          * @param user_pin User PIN
          */
+        [[deprecated("set_unencrypted_read_write is deprecated. Use set_unencrypted_read_write_admin instead")]]
         void set_unencrypted_read_write(const char *user_pin);
 
         /**

--- a/libnitrokey/NitrokeyManager.h
+++ b/libnitrokey/NitrokeyManager.h
@@ -158,7 +158,7 @@ char * strndup(const char* str, size_t maxlen);
          * Does nothing otherwise.
          * @param user_pin User PIN
          */
-        [[deprecated("set_unencrypted_read_only is deprecated. Use set_unencrypted_read_only_admin instead.")]]
+        [[deprecated("Use set_unencrypted_read_only_admin instead.")]]
         void set_unencrypted_read_only(const char *user_pin);
 
         /**
@@ -175,7 +175,7 @@ char * strndup(const char* str, size_t maxlen);
          * Does nothing otherwise.
          * @param user_pin User PIN
          */
-        [[deprecated("set_unencrypted_read_write is deprecated. Use set_unencrypted_read_write_admin instead")]]
+        [[deprecated("Use set_unencrypted_read_write_admin instead")]]
         void set_unencrypted_read_write(const char *user_pin);
 
         /**


### PR DESCRIPTION
Add C++14 `deprecate` attributes to UV's ro/rw attribute setters, which accepts User PIN (old Nitrokey Storage firmwares).