### PR TITLE
Fix libnitrokey-1.pc generation on FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,8 @@ set(SOURCE_FILES
 set(BUILD_SHARED_LIBS ON CACHE BOOL "Build all libraries as shared")
 add_library(nitrokey ${SOURCE_FILES})
 
+set(HIDAPI_LIBUSB_NAME hidapi-libusb)
+
 IF(APPLE)
     include_directories(hidapi/hidapi)
     add_library(hidapi-libusb STATIC hidapi/mac/hid.c )
@@ -83,6 +85,7 @@ ELSEIF(UNIX)
     find_package(PkgConfig)
     IF(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
         pkg_search_module(HIDAPI_LIBUSB REQUIRED hidapi)
+        set(HIDAPI_LIBUSB_NAME hidapi)
     ELSE()
         pkg_search_module(HIDAPI_LIBUSB REQUIRED hidapi-libusb)
     ENDIF()

--- a/libnitrokey.pc.in
+++ b/libnitrokey.pc.in
@@ -4,7 +4,7 @@ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 Name: libnitrokey
 Description: Library for communicating with Nitrokey in a clean and easy manner
 Version: @libnitrokey_VERSION@
-Requires.private: hidapi-libusb
+Requires.private: @HIDAPI_LIBUSB_NAME@
 
 Libs: -L${libdir} -lnitrokey
 Cflags: -I${includedir}

--- a/meson.build
+++ b/meson.build
@@ -107,12 +107,22 @@ ext_libnitrokey = declare_dependency(
   include_directories : inc_libnitrokey,
 )
 
+if meson.version().version_compare('>= 0.48.0') 
+  dep_hidapi_name = dep_hidapi.name()
+else
+  if target_machine.system() == 'freebsd'
+    dep_hidapi_name = 'hidapi'
+  else
+    dep_hidapi_name = 'hidapi-libusb'
+  endif
+endif
+
 pkg.generate(
   name : meson.project_name(),
   filebase : 'libnitrokey-1',
   libraries : libnitrokey,
   version : meson.project_version(),
-  requires_private : 'hidapi-libusb',
+  requires_private : dep_hidapi_name,
   description : 'Library for communicating with Nitrokey in a clean and easy manner',
   install : true,
 )


### PR DESCRIPTION
Add a cmake variable to store the hidapi libusb name to use in the `requires.private` section of the `libnitrokey.pc.in`
For the meson build system use the `name()` method of the dependency to fill the `requires.private` section.

The meson `name()` method exist since version 0.48.0, so add a workaround for lower version