### PR TITLE
Fix infinite loop in add_vendor_devices

### DIFF
--- a/device.cc
+++ b/device.cc
@@ -234,6 +234,7 @@ namespace {
     auto pInfo_ = pInfo;
     while (pInfo != nullptr){
       if (pInfo->path == nullptr || pInfo->serial_number == nullptr) {
+      pInfo = pInfo->next;
       continue;
     }
     auto deviceModel = product_id_to_model(vendor_id, pInfo->product_id);


### PR DESCRIPTION
This patch fixes an infinite lopp in add_vendor_devices that is
triggered if a Nitrokey device without a serial number is connected to
the system, e. g. the Nitrokey FIDO 2.

Fixes #193.