### PR TITLE
Support custom log functions using the C API

### DIFF
--- a/NK_C_API.cc
+++ b/NK_C_API.cc
@@ -426,6 +426,14 @@ extern "C" {
 		m->set_loglevel(level);
 	}
 
+	NK_C_API void NK_set_log_function(NK_log_function fn) {
+		auto m = NitrokeyManager::instance();
+		std::function<void(const std::string&, Loglevel)> log_function = [fn](auto s, auto lvl) {
+		    fn(static_cast<int>(lvl), s.c_str());
+		};
+		m->set_log_function_raw(log_function);
+        }
+
 	NK_C_API unsigned int NK_get_major_library_version() {
 		return get_major_library_version();
 	}

--- a/NK_C_API.h
+++ b/NK_C_API.h
@@ -331,6 +331,21 @@ extern "C" {
 	NK_C_API void NK_set_debug_level(const int level);
 
 	/**
+	 * Callback function for NK_set_log_function.  The first argument is
+	 * the log level (0 = Error, 1 = Warn, 2 = Info, 3 = DebugL1,
+	 * 4 = Debug, 5 = DebugL2) and the second argument is the log message.
+	 */
+	typedef void (*NK_log_function)(int, const char*);
+
+	/**
+	 * Set a custom log function.
+	 *
+	 * The log function is called for every log message that matches the
+	 * log level settings (see NK_set_debug and NK_set_debug_level).
+	 */
+	NK_C_API void NK_set_log_function(NK_log_function fn);
+
+	/**
 	 * Get the major library version, e. g. the 3 in v3.2.
 	 * @return the major library version
 	 */

--- a/NitrokeyManager.cc
+++ b/NitrokeyManager.cc
@@ -277,6 +277,11 @@ using nitrokey::misc::strcpyT;
       nitrokey::log::Log::instance().set_handler(&handler);
     }
 
+    void NitrokeyManager::set_log_function_raw(std::function<void(const std::string&, Loglevel)> log_function) {
+      static nitrokey::log::RawFunctionalLogHandler handler(log_function);
+      nitrokey::log::Log::instance().set_handler(&handler);
+    }
+
     bool NitrokeyManager::set_default_commands_delay(int delay){
       if (delay < 20){
         LOG("Delay set too low: " + to_string(delay), Loglevel::WARNING);

--- a/libnitrokey/NitrokeyManager.h
+++ b/libnitrokey/NitrokeyManager.h
@@ -222,6 +222,7 @@ char * strndup(const char* str, size_t maxlen);
 
         explicit NitrokeyManager();
         void set_log_function(std::function<void(std::string)> log_function);
+        void set_log_function_raw(std::function<void(const std::string&, Loglevel)> log_function);
     private:
 
         static shared_ptr <NitrokeyManager> _instance;

--- a/libnitrokey/log.h
+++ b/libnitrokey/log.h
@@ -67,6 +67,15 @@ namespace nitrokey {
 
     };
 
+    class RawFunctionalLogHandler : public LogHandler {
+      using log_function_type = std::function<void(const std::string&, Loglevel lvl)>;
+      log_function_type log_function;
+    public:
+      RawFunctionalLogHandler(log_function_type _log_function);
+      virtual void print(const std::string &, Loglevel lvl);
+
+    };
+
     extern StdlogHandler stdlog_handler;
 
     class Log {

--- a/log.cc
+++ b/log.cc
@@ -77,6 +77,10 @@ namespace nitrokey {
       log_function(s);
     }
 
+    void RawFunctionalLogHandler::print(const std::string &str, Loglevel lvl) {
+      log_function(str, lvl);
+    }
+
     std::string LogHandler::format_message_to_string(const std::string &str, const Loglevel &lvl) {
       static bool last_short = false;
       if (str.length() == 1){
@@ -97,6 +101,10 @@ namespace nitrokey {
     }
 
     FunctionalLogHandler::FunctionalLogHandler(log_function_type _log_function) {
+      log_function = _log_function;
+    }
+
+    RawFunctionalLogHandler::RawFunctionalLogHandler(log_function_type _log_function) {
       log_function = _log_function;
     }
   }


### PR DESCRIPTION
This patch adds the NK_set_log_level function to the C API that makes it
possible to set a custom log function.  Fixes #202.