### PR TITLE
Don't copy strings needlessly in NK_list_devices_by_cpuID

### DIFF
--- a/NK_C_API.cc
+++ b/NK_C_API.cc
@@ -829,7 +829,7 @@ NK_C_API char* NK_get_SD_usage_data_as_string() {
 		return get_with_string_result([&]() {
 			auto v = nm->list_devices_by_cpuID();
 			std::string res;
-			for (const auto a : v){
+			for (const auto& a : v){
 				res += a+";";
 			}
 			if (res.size()>0) res.pop_back(); // remove last delimiter char


### PR DESCRIPTION
An `auto` variable being assigned to may cause a copy of the object, even
if only a reference is necessary (and desired). That can easily be cause
for performance issues, especially in `for` loops.
This change fixes one such problem found in the `NK_list_devices_by_cpuID`
function.