### PR TITLE
Fix build with meson >= 0.60.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -114,7 +114,6 @@ pkg.generate(
   version : meson.project_version(),
   requires_private : dep_hidapi.name(),
   description : 'Library for communicating with Nitrokey in a clean and easy manner',
-  install : true,
 )
 
 if target_machine.system() == 'freebsd'


### PR DESCRIPTION
Meson pkgconfig.generate never supported the `install` keyword, but it
only issued a warning until meson commit 0.60.0.rc1~221 ("decorators:
Make unknown kwarg fatal") turned use of unsupported keywords into an
error.

Error message:
meson.build:110:4: ERROR: Got unknown keyword arguments "install"