### PR TITLE
Do not return local variable address for TargetBufferSmallerThanSource message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ set_target_properties(nitrokey PROPERTIES
 
 OPTION(ERROR_ON_WARNING "Stop compilation on warning found (not supported for MSVC)" OFF)
 if (NOT MSVC)
-    set(COMPILE_FLAGS "-Wall -Wno-unused-function -Wcast-qual -Woverloaded-virtual -Wsign-compare -Wformat -Wformat-security")
+    set(COMPILE_FLAGS "-Wall -Wno-unused-function -Wcast-qual -Woverloaded-virtual -Wsign-compare -Wformat -Wformat-security -Wreturn-local-addr")
     IF(NOT APPLE)
         if (ERROR_ON_WARNING)
             set(COMPILE_FLAGS "${COMPILE_FLAGS} -Werror")

--- a/libnitrokey/stick10_commands_0.8.h
+++ b/libnitrokey/stick10_commands_0.8.h
@@ -131,7 +131,7 @@ namespace nitrokey {
                       std::stringstream ss;
 #ifdef LOG_VOLATILE_DATA
                       ss << "data:" << std::endl
-                         << ::nitrokey::misc::hexdump(reinterpret_cast<const uint8_t *>&data), sizeof data);
+                         << ::nitrokey::misc::hexdump(reinterpret_cast<const uint8_t *> (&data), sizeof data);
 #else
                       ss << " Volatile data not logged" << std::endl;
 #endif


### PR DESCRIPTION
Use static string object for keeping the c_str message for the caller.
Strings collection used as an alternative to memory leaks done via strdup().
To add, TargetBufferSmallerThanSource Exception should never happen in a correctly written library client, as this completely depends on the implementation and not on the communication with the device

Downside: if missed and when occurring too often, the memory taken by the exception messages can take too much memory.
Potential improvement: replace std::vector with a kind of a ring buffer, or add simple wrapping logic over it.

Fixes #214 


Edit: this should avoid breaking ABI by using static memory. Note: there might be multiple exceptions' strings collections (for each compilation unit including this header).
Edit: correct that for libnitrokey 4, by keeping string as a member of the exception.