### PR TITLE
Update USB device id descriptions

### DIFF
--- a/data/41-nitrokey.rules
+++ b/data/41-nitrokey.rules
@@ -31,11 +31,11 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="2581", ATTRS{idProduct
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4287", TAG+="uaccess"
 # Nitrokey FIDO2
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42b1", TAG+="uaccess"
-# Nitrokey 3
+# Nitrokey 3A Mini/3A NFC/3C NFC
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42b2", TAG+="uaccess"
-# Nitrokey 3 Bootloader
+# Nitrokey 3A NFC Bootloader/3C NFC Bootloader
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42dd", TAG+="uaccess"
-# Nitrokey 3 Bootloader NRF
+# Nitrokey 3A Mini Bootloader
 ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42e8", TAG+="uaccess"
 
 LABEL="u2f_end"

--- a/data/41-nitrokey_old.rules
+++ b/data/41-nitrokey_old.rules
@@ -32,11 +32,11 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="2581", ATTRS{idProduct
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4287", MODE="0660", GROUP+="plugdev"
 # Nitrokey FIDO2
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42b1", MODE="0660", GROUP+="plugdev"
-# Nitrokey 3
+# Nitrokey 3A Mini/3A NFC/3C NFC
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42b2", MODE="0660", GROUP+="plugdev"
-# Nitrokey 3 Bootloader
+# Nitrokey 3A NFC Bootloader/3C NFC Bootloader
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42dd", MODE="0660", GROUP+="plugdev"
-# Nitrokey 3 Bootloader NRF
+# Nitrokey 3A Mini Bootloader
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42e8", MODE="0660", GROUP+="plugdev"
 
 LABEL="u2f_end"

--- a/data/README.md
+++ b/data/README.md
@@ -1,20 +1,20 @@
 
 The specified USB IDs in the Udev rules file are as follows:
 
-| Name                                     |  USB ID   |
-|------------------------------------------|:---------:|
-| Crypto Stick 1.2                         | 20a0:4107 |
-| Nitrokey 3 NFC                           | 20a0:42b2 |
-| Nitrokey 3 NFC Bootloader                | 20a0:42dd |
-| Nitrokey 3 NFC Bootloader NRF            | 20a0:42e8 |
-| Nitrokey FIDO U2F                        | 20a0:4287 |
-| Nitrokey FIDO2                           | 20a0:42b1 |
-| Nitrokey HSM                             | 20a0:4230 |
-| Nitrokey Pro                             | 20a0:4108 |
-| Nitrokey Pro Bootloader                  | 20a0:42b4 |
-| Nitrokey Start                           | 20a0:4211 |
-| Nitrokey Storage                         | 20a0:4109 |
-| Nitrokey Storage Bootloader              | 03eb:2ff1 |
-| Nitrokey U2F                             | 2581:f1d0 |
+| Name                                         |  USB ID   |
+|----------------------------------------------|:---------:|
+| Crypto Stick 1.2                             | 20a0:4107 |
+| Nitrokey 3A Mini/3A NFC/3C NFC               | 20a0:42b2 |
+| Nitrokey 3A NFC Bootloader/3C NFC Bootloader | 20a0:42dd |
+| Nitrokey 3A Mini Bootloader                  | 20a0:42e8 |
+| Nitrokey FIDO U2F                            | 20a0:4287 |
+| Nitrokey FIDO2                               | 20a0:42b1 |
+| Nitrokey HSM                                 | 20a0:4230 |
+| Nitrokey Pro                                 | 20a0:4108 |
+| Nitrokey Pro Bootloader                      | 20a0:42b4 |
+| Nitrokey Start                               | 20a0:4211 |
+| Nitrokey Storage                             | 20a0:4109 |
+| Nitrokey Storage Bootloader                  | 03eb:2ff1 |
+| Nitrokey U2F                                 | 2581:f1d0 |
 
 Generated from `41-nitrokey.rules`.


### PR DESCRIPTION
This PR updates the descriptions for the USB device ids of the Nitrokey 3 models.