### PR TITLE
Change usb ids documentation reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,20 +434,4 @@ To check what issues will be fixed and when please check [milestones](https://gi
 
 # Nitrokey USB IDs
 
-Currently used USB identifiers for Nitrokey products are listed below. See [./data](./data) for the further details.
-
-| Name                        |  USB ID   |
-|-----------------------------|:---------:|
-| Crypto Stick 1.2            | 20a0:4107 |
-| Nitrokey 3                  | 20a0:42b2 |
-| Nitrokey 3 Bootloader       | 20a0:42dd |
-| Nitrokey 3 Bootloader NRF   | 20a0:42e8 |
-| Nitrokey FIDO U2F           | 20a0:4287 |
-| Nitrokey FIDO2              | 20a0:42b1 |
-| Nitrokey HSM                | 20a0:4230 |
-| Nitrokey Pro                | 20a0:4108 |
-| Nitrokey Pro Bootloader     | 20a0:42b4 |
-| Nitrokey Start              | 20a0:4211 |
-| Nitrokey Storage            | 20a0:4109 |
-| Nitrokey Storage Bootloader | 03eb:2ff1 |
-| Nitrokey U2F                | 2581:f1d0 |
+For a list of USB identifiers for Nitrokey products, please refer to the [data](./data) subdirectory.


### PR DESCRIPTION
This PR removes the table of USB device ids from the README in the root to replace it with a link to the `data` subdirectory. Motivation for the change is to avoid inconsistencies because of duplication.